### PR TITLE
Ignore search response if filters were cleared mid flight

### DIFF
--- a/src/app/store/search/search.action.ts
+++ b/src/app/store/search/search.action.ts
@@ -6,10 +6,20 @@ export enum SearchActionType {
   MAKE_SEARCH = '[Search] Make A Search',
   SEARCH_RESPONSE = '[Search] Search Response',
   SEARCH_ERROR = '[Search] Search Error',
+  CANCEL_SEARCH = '[Search] Cancel Search',
+  SEARCH_CANCELED = '[Search] Search Canceled',
 }
 
 export class MakeSearch implements Action {
   public readonly type = SearchActionType.MAKE_SEARCH;
+}
+
+export class CancelSearch implements Action {
+  public readonly type = SearchActionType.CANCEL_SEARCH;
+}
+
+export class SearchCanceled implements Action {
+  public readonly type = SearchActionType.SEARCH_CANCELED;
 }
 
 export class SearchResponse implements Action {
@@ -26,5 +36,6 @@ export class SearchError implements Action {
 
 export type SearchActions =
   | MakeSearch
+  | CancelSearch
   | SearchError
   | SearchResponse;

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -1,22 +1,28 @@
 import { Injectable } from '@angular/core';
 
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { Action } from '@ngrx/store';
+import { Action, Store } from '@ngrx/store';
 
 import { Observable, of } from 'rxjs';
 import { map, withLatestFrom, switchMap, catchError } from 'rxjs/operators';
 
 import { AppState } from '../app.reducer';
 import * as granulesStore from '@store/granules';
+import * as filtersStore from '@store/filters';
 
 import * as services from '@services';
 
-import { SearchActionType, SearchResponse, SearchError } from './search.action';
+import {
+  SearchActionType,
+  SearchResponse, SearchError, CancelSearch, SearchCanceled
+} from './search.action';
+import { getIsCanceled } from './search.reducer';
 
 @Injectable()
 export class SearchEffects {
   constructor(
     private actions$: Actions,
+    private store$: Store<AppState>,
     private searchParams$: services.SearchParamsService,
     private asfApiService: services.AsfApiService,
     private productService: services.ProductService,
@@ -30,10 +36,19 @@ export class SearchEffects {
     map(([_, params]) => params),
     switchMap(
       params => this.asfApiService.query<any[]>(params).pipe(
-        map(response => new SearchResponse(response)),
+        withLatestFrom(this.store$.select(getIsCanceled)),
+        map(([response, isCanceled]) =>
+          !isCanceled ?  new SearchResponse(response) : new SearchCanceled()
+        ),
         catchError(error => of(new SearchError(`${error.message}`))),
       )
     ),
+  );
+
+  @Effect()
+  private cancelSearchWhenFiltersCleared: Observable<Action> = this.actions$.pipe(
+    ofType(filtersStore.FiltersActionType.CLEAR_FILTERS),
+    map(_ => new CancelSearch())
   );
 
   @Effect()

--- a/src/app/store/search/search.reducer.ts
+++ b/src/app/store/search/search.reducer.ts
@@ -6,11 +6,13 @@ import { SearchActionType, SearchActions } from './search.action';
 export interface SearchState {
   isLoading: boolean;
   error: null | string;
+  isCanceled: boolean;
 }
 
 export const initState: SearchState = {
   isLoading: false,
   error: null,
+  isCanceled: false,
 };
 
 export function searchReducer(state = initState, action: SearchActions): SearchState {
@@ -19,14 +21,24 @@ export function searchReducer(state = initState, action: SearchActions): SearchS
       return {
         ...state,
         error: null,
-        isLoading: true
+        isLoading: true,
+        isCanceled: false,
+      };
+    }
+
+    case SearchActionType.CANCEL_SEARCH: {
+      return {
+        ...state,
+        isLoading: false,
+        isCanceled: true,
       };
     }
 
     case SearchActionType.SEARCH_RESPONSE: {
       return {
         ...state,
-        isLoading: false
+        isLoading: false,
+        isCanceled: false,
       };
     }
 
@@ -54,4 +66,9 @@ export const getIsLoading = createSelector(
 export const getSearchError = createSelector(
   getSearchState,
   (state: SearchState) => state.error
+);
+
+export const getIsCanceled = createSelector(
+  getSearchState,
+  (state: SearchState) => state.isCanceled
 );


### PR DESCRIPTION
This stops results from showing up if the user cleared the filters after they hit search, but before the results come back.