### PR TITLE
DS-2497 Use utc date strings when making api queries

### DIFF
--- a/src/app/components/shared/selectors/date-selector/date-selector.component.ts
+++ b/src/app/components/shared/selectors/date-selector/date-selector.component.ts
@@ -51,12 +51,15 @@ export class DateSelectorComponent implements OnInit {
   }
 
   public onStartDateChange(e: MatDatepickerInputEvent<moment.Moment>) {
-    const date = this.toJSDate(e.value);
+    const momentDate = e.value.set({h: 0});
+    const date = this.toJSDate(momentDate);
+
     this.store$.dispatch(new filtersStore.SetStartDate(date));
   }
 
   public onEndDateChange(e: MatDatepickerInputEvent<moment.Moment>) {
-    const date = this.toJSDate(e.value);
+    const momentDate = e.value.set({h: 23});
+    const date = this.toJSDate(momentDate);
     this.store$.dispatch(new filtersStore.SetEndDate(date));
   }
 

--- a/src/app/services/search-params.service.ts
+++ b/src/app/services/search-params.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpParams } from '@angular/common/http';
 
 import { Store, Action } from '@ngrx/store';
+import * as moment from 'moment';
 
 import { Observable, combineLatest } from 'rxjs';
 import { map, withLatestFrom, startWith, switchMap, tap, filter } from 'rxjs/operators';
@@ -116,7 +117,7 @@ export class SearchParamsService {
     return this.store$.select(filterStore.getDateRange).pipe(
       map(range => {
         return [range.start, range.end]
-          .map(date => !!date ? date.toISOString() : date);
+          .map(date => !!date ? moment.utc( date ).format() : date);
       }),
       map(([start, end]) => ({ start, end })),
     );

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Router, ActivatedRoute, Params } from '@angular/router';
 
 import { Store } from '@ngrx/store';
+import * as moment from 'moment';
 
 import { combineLatest } from 'rxjs';
 import { filter, map, switchMap, skip, tap, withLatestFrom } from 'rxjs/operators';
@@ -158,14 +159,14 @@ export class UrlStateService {
       name: 'start',
       source: this.store$.select(filterStore.getStartDate).pipe(
         skip(1),
-        map(start => ({ start }))
+        map(start => ({ start: moment.utc( start ).format() }))
       ),
       loader: this.loadStartDate
     }, {
       name: 'end',
       source: this.store$.select(filterStore.getEndDate).pipe(
         skip(1),
-        map(end => ({ end }))
+        map(end => ({ end: moment.utc( end ).format() }))
       ),
       loader: this.loadEndDate
     }, {


### PR DESCRIPTION
This change might break loading start/end dates from links because utc format is now used to save vs whatever the js date object defaulted to. 

https://asfdaac.atlassian.net/browse/DS-2497