### PR TITLE
DS-2037 Made the zoom icon in the granule result list turn red for th…

### DIFF
--- a/src/app/components/bottom-menu/granules-list/granules-list.component.scss
+++ b/src/app/components/bottom-menu/granules-list/granules-list.component.scss
@@ -29,3 +29,7 @@
 .icon-margin {
   margin-left: 10px;
 }
+
+.selected .ml-2 {
+  color: red;
+}

--- a/src/styles/asf-theme.scss
+++ b/src/styles/asf-theme.scss
@@ -15,7 +15,6 @@ $asf-app-primary: mat-palette($mat-asf-primary, 700, 400, 900);
 $asf-app-accent:  mat-palette($mat-grey, 300, 100, 400);
 
 // The warn palette is optional (defaults to red).
-//$asf-app-warn:    mat-palette($mat-asf-yellow, 200, 100, 500);
 $asf-app-warn:    mat-palette($mat-asf-yellow, 200, 100, 500);
 
 // Create the theme object (a Sass map containing all of the palettes).


### PR DESCRIPTION
DS-2037 Made the zoom icon in the granule result list turn red for the currently selected granule. In this way, it matches the frame color on the map making a stronger visual connection between the granule in the list and the granule highlighted on the map.