### PR TITLE
Redirect vertex.daac and vertex-beta traffic to search.asf.alaska.edu

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,16 @@
   <script src="./assets/env.js" type="text/javascript"></script>
 </head>
 <body>
+<script>
+
+const url = window.location.hostname.toLowerCase();
+
+if (url === 'vertex-beta.asf.alaska.edu' || url === 'vertex.daac.asf.alaska.edu') {
+  const redirect = `https://search.asf.alaska.edu${window.location.pathname}${window.location.hash}`;
+  window.location = redirect;
+}
+
+</script>
   <style>
   body {
     padding: 0;


### PR DESCRIPTION
Note that the vertex.daac redirect will NOT have any effect until the vertex.daac CNAME has been updated to point to the search app host. This is NOT an ahead-of-schedule changeover, merely anticipatory.