### PR TITLE
Only show errors when manually saving searches

### DIFF
--- a/src/app/services/saved-search.service.ts
+++ b/src/app/services/saved-search.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { Store, Action } from '@ngrx/store';
 import { Actions, ofType } from '@ngrx/effects';
@@ -53,7 +52,6 @@ export class SavedSearchService {
     private store$: Store<AppState>,
     private actions$: Actions,
     private mapService: MapService,
-    private snackBar: MatSnackBar,
   ) {
     this.currentSearch$.subscribe(
       current => this.currentSearch = current
@@ -65,39 +63,12 @@ export class SavedSearchService {
   }
 
   public makeCurrentSearch(searchName: string): models.Search | null {
-    const maxLen = 10000;
-
-    if (this.searchType === models.SearchType.DATASET) {
-      const filters = <models.GeographicFiltersType>this.currentSearch;
-      const len = filters.polygon !== null ? filters.polygon.length : 0;
-
-      if (len > maxLen) {
-        this.notifyUserListTooLong(len, 'List');
-        return;
-      }
-    } else if (this.searchType === models.SearchType.LIST) {
-      const filters = <models.ListFiltersType>this.currentSearch;
-      const len = filters.list.join(',').length;
-
-      if (len > maxLen) {
-        this.notifyUserListTooLong(len, 'List');
-        return;
-      }
-    }
-
     return {
       name: searchName,
       id: uuid(),
       filters: this.currentSearch,
       searchType: this.searchType,
     };
-  }
-
-  private notifyUserListTooLong(len: number, strType: string): void {
-    this.snackBar.open(
-      `${strType} too long, must be under 10,000 charecters (${len.toLocaleString()})`, `ERROR`,
-      { duration: 4000, }
-    );
   }
 
   public updateSearchWithCurrentFilters(id: string): void {


### PR DESCRIPTION
This supresses errors when searches are saved for search history.