### PR TITLE
fix snackbar feedback for hyp3 job submission faiures

### DIFF
--- a/src/app/store/hyp3/hyp3.effect.ts
+++ b/src/app/store/hyp3/hyp3.effect.ts
@@ -44,7 +44,9 @@ export class Hyp3Effects {
   private submitJob = createEffect(() => this.actions$.pipe(
     ofType<SubmitJob>(Hyp3ActionType.SUBMIT_JOB),
     switchMap(action => this.hyp3Service.submitJob$(action.payload).pipe(
-      map(_ => new SuccessfulJobSumbission()),
+      map((jobs: any) => {
+        return new SuccessfulJobSumbission();
+      }),
       catchError(err => of(new ErrorJobSubmission())),
     ))
   ));

--- a/src/app/store/hyp3/hyp3.effect.ts
+++ b/src/app/store/hyp3/hyp3.effect.ts
@@ -5,8 +5,8 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, Action } from '@ngrx/store';
 
-import { Observable, combineLatest } from 'rxjs';
-import { map, withLatestFrom, startWith, switchMap, tap, filter, delay } from 'rxjs/operators';
+import { Observable, combineLatest, of } from 'rxjs';
+import { map, withLatestFrom, startWith, switchMap, tap, filter, delay, catchError } from 'rxjs/operators';
 
 import { Hyp3Service, AsfApiService, ProductService } from '@services';
 import { AppState } from '../app.reducer';
@@ -44,15 +44,8 @@ export class Hyp3Effects {
   private submitJob = createEffect(() => this.actions$.pipe(
     ofType<SubmitJob>(Hyp3ActionType.SUBMIT_JOB),
     switchMap(action => this.hyp3Service.submitJob$(action.payload).pipe(
-      map((jobs: any) => {
-        const [job] = jobs.jobs;
-
-        if ( job.status_code === 'PENDING' ) {
-          return new SuccessfulJobSumbission();
-        } else {
-          return new ErrorJobSubmission();
-        }
-      })
+      map(_ => new SuccessfulJobSumbission()),
+      catchError(err => of(new ErrorJobSubmission())),
     ))
   ));
 

--- a/src/app/store/hyp3/hyp3.effect.ts
+++ b/src/app/store/hyp3/hyp3.effect.ts
@@ -62,7 +62,7 @@ export class Hyp3Effects {
   private errorJobSubmission = createEffect(() => this.actions$.pipe(
     ofType<SubmitJob>(Hyp3ActionType.ERROR_JOB_SUBMISSION),
     map(action => this.snackbar.open(
-      'Fail to submit job', 'RTC_GAMMA',
+      'Failed to submit job', 'RTC_GAMMA',
       { duration: 3000 }
     ))
   ), {dispatch: false});


### PR DESCRIPTION
I've tested this locally for a good granule and a bad granule and it seems to work, but I'm way out of my element so don't trust me.  I just copy/pasted from error handling for the unzip-api service.

An api success will be a HTTP 200 with a response body like:
```
{
  "jobs": [
    {
      "job_id": "27836b79-e5b2-4d8f-932f-659724ea02c3",
      "job_parameters": {
        "granule": "S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8"
      },
      "job_type": "RTC_GAMMA",
      "name": "Job Name",
      "request_time": "2020-06-04T18:00:03+00:00",
      "status_code": "SUCCEEDED",
      "user_id": "myUserId"
    }
  ]
}
```

An api failure will be a HTTP 4xx or 5xx with a response body like:
```
{
  "detail": "Some requested scenes do not have DEM coverage: S1B_IW_GRDH_1SDV_20200901T160749_20200901T160821_023184_02C05B_C348",
  "status": 400,
  "title": "Bad Request",
  "type": "about:blank"
}
```

For errors I'd love to render `response_body.detail` for the user to see, but I'm out of my depth to implement that.