### PR TITLE
support hyp3 api change exposing granule job parameters as a list

### DIFF
--- a/src/app/models/hyp3.model.ts
+++ b/src/app/models/hyp3.model.ts
@@ -55,7 +55,7 @@ export type Hyp3JobParameters =
   | Hyp3RtcGammaParameters;
 
 export interface Hyp3RtcGammaParameters {
-  granule: string;
+  granules: string[];
 }
 
 export enum Hyp3JobType {

--- a/src/app/services/hyp3.service.ts
+++ b/src/app/services/hyp3.service.ts
@@ -51,7 +51,7 @@ export class Hyp3Service {
       jobs: [{
         name: name || 'RTC HyP3 job',
         job_parameters: {
-          granule: granuleId
+          granules: [granuleId]
         },
         job_type: 'RTC_GAMMA'
       }]
@@ -67,7 +67,7 @@ export class Hyp3Service {
         {
           'job_id': '54ff6e59-d277-4d53-b067-8750225aeaa1',
           'job_parameters': {
-            'granule': 'S1A_IW_SLC__1SDV_20200701T154834_20200701T154900_033263_03DA96_C249'
+            'granules': ['S1A_IW_SLC__1SDV_20200701T154834_20200701T154900_033263_03DA96_C249']
           },
           'job_type': 'RTC_GAMMA',
           'name': 'RTC HyP3 job',

--- a/src/app/services/scenes.service.ts
+++ b/src/app/services/scenes.service.ts
@@ -51,7 +51,7 @@ export class ScenesService {
     ).pipe(
       map(([scenes, jobs]) => {
         const jobsByName = jobs.reduce((byName, job) => {
-          byName[job.job_parameters.granule] = job;
+          byName[job.job_parameters.granules[0]] = job;
           return byName;
         }, {});
 

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -147,7 +147,7 @@ export class SearchEffects {
       switchMap(
         (jobs: models.Hyp3Job[]) => {
           const granules = jobs.map(
-            job => job.job_parameters.granule
+            job => job.job_parameters.granules[0]
           ).join(',');
 
           return this.asfApiService.query<any[]>({ 'granule_list': granules }).pipe(
@@ -181,7 +181,7 @@ export class SearchEffects {
   private hyp3JobToProducts(jobs, products) {
     const virtualProducts = jobs
       .map(job => {
-        const product = products[job.job_parameters.granule];
+        const product = products[job.job_parameters.granules[0]];
         const jobFile = !!job.files ?
           job.files[0] :
           {size: -1, url: ''};


### PR DESCRIPTION
This should address the soon-ish-to-be-released [hyp3 v0.6.0](https://github.com/ASFHyP3/hyp3/blob/develop/CHANGELOG.md#060) that will add the INSAR_GAMMA job_type, and expose granule parameters as a list for all job types.  These are the minimum changes to keep from breaking existing functionality (just use the first granule in the list when rendering search results), more work will be needed later to support submission and improved rendering of INSAR_GAMMA jobs.