### PR TITLE
DS-3288 SBAS Mobile: Cannot see entire chart axis label at default re…

### DIFF
--- a/src/app/components/sbas-chart/sbas-chart.component.ts
+++ b/src/app/components/sbas-chart/sbas-chart.component.ts
@@ -143,10 +143,10 @@ export class SBASChartComponent implements OnInit, OnDestroy {
       .attr('class', 'y label')
       .attr('text-anchor', 'end')
       .attr('y', -this.margin.left)
-      .attr('x', -((this.heightValue - (this.margin.top)) / 2) + 80)
+      .attr('x', -((this.heightValue - (this.margin.top)) / 2) + 60)
       .attr('dy', '.75em')
       .attr('transform', 'rotate(-90)')
-      .text('Perpendicular Baseline');
+      .text('Perp. Baseline');
 
     const xExtent = d3.extent(
       this.scenes.map(s => s.metadata.date.valueOf())


### PR DESCRIPTION
…sults window size. I changed the text to "Perp. Baseline". I don't like the abbreviation, but I don't have many alternatives. I could just make it say "Baseline" but we refer to "Perpendicular" in the filters.