### PR TITLE
Add baseline header menu export stack button

### DIFF
--- a/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.html
+++ b/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.html
@@ -11,19 +11,16 @@
   </mat-card>
 
   <mat-card class="mp0 no-box-shadow" fxFlex="21" fxFlexFill>
-    <mat-card-subtitle class="header">
-      Scene Detail
-    </mat-card-subtitle>
+    <mat-card-subtitle class="header"> Scene Detail </mat-card-subtitle>
 
     <app-scene-detail></app-scene-detail>
   </mat-card>
 </ng-container>
 
 <ng-container *ngIf="breakpoint <= breakpoints.MEDIUM">
-  <mat-card *ngIf="view === Views.LIST"  class="mp0" fxFlex="45" fxFlex>
+  <mat-card *ngIf="view === Views.LIST" class="mp0" fxFlex="45" fxFlex>
     <mat-card-subtitle class="header medium-header">
       <div>
-
         <div fxFlex="" class="list-button-group">
           <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
             &nbsp;
@@ -32,7 +29,9 @@
             <div>
               <span fxFlex="" class="mr-10">
                 <span class="control-mat-button-toggle scene-text">
-                  {{ numBaselineScenes$ | async }} Scene{{ (numBaselineScenes$ | async) === 1 ? '' : 's' }}
+                  {{ numBaselineScenes$ | async }} Scene{{
+                    (numBaselineScenes$ | async) === 1 ? "" : "s"
+                  }}
                 </span>
               </span>
             </div>
@@ -45,10 +44,14 @@
           <div fxLayout="row">
             <div>
               <mat-button-toggle-group fxFlex="" name="layerType" class="mr-10">
-                <mat-button-toggle (click)="onZoomToResults()" class="control-mat-button-toggle">
+                <mat-button-toggle
+                  (click)="onZoomToResults()"
+                  class="control-mat-button-toggle"
+                >
                   <mat-icon
                     class="clickable noselect list-icon"
-                    matTooltip="Zoom to results">
+                    matTooltip="Zoom to results"
+                  >
                     settings_overscan
                   </mat-icon>
                 </mat-button-toggle>
@@ -67,7 +70,8 @@
                   <mat-icon
                     class="clickable noselect list-icon"
                     matTooltip="Add all results to downloads"
-                    [matMenuTriggerFor]="addAllProducts">
+                    [matMenuTriggerFor]="addAllProducts"
+                  >
                     add_shopping_cart
                   </mat-icon>
                 </mat-button-toggle>
@@ -75,26 +79,88 @@
             </div>
           </div>
         </div>
+        <div fxFlex="" class="list-button-group">
+          <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
+            <label>Download</label>
+          </div>
+          <div fxLayout="row">
+            <div>
+              <mat-button-toggle-group fxFlex="" name="layerType" class="mr-10">
+                <mat-button-toggle class="control-mat-button-toggle">
+                  <mat-icon
+                    class="clickable noselect list-icon"
+                    matTooltip="Download data/metadata as"
+                    [matMenuTriggerFor]="addAllOnDemand"
+                  >
+                    get_app
+                  </mat-icon>
+                </mat-button-toggle>
+              </mat-button-toggle-group>
+            </div>
+          </div>
+        </div>
 
-        <mat-menu #addAllProducts="matMenu" >
+        <mat-menu #addAllProducts="matMenu">
           <div *ngIf="allProducts$ | async as products">
             <button (click)="queueAllProducts(products)" mat-menu-item>
-              Add {{ downloadable(products).length }} file{{ downloadable(products).length === 1 ? '' : 's'}} to downloads
+              Add {{ downloadable(products).length }} file{{
+                downloadable(products).length === 1 ? "" : "s"
+              }}
+              to downloads
             </button>
           </div>
         </mat-menu>
 
+        <mat-menu #addAllOnDemand="matMenu">
+          <button mat-menu-item [matMenuTriggerFor]="addAllOnDemandMetadata">
+            Metadata
+          </button>
+          <button mat-menu-item [matMenuTriggerFor]="addAllOnDemandData">
+            Data
+          </button>
+        </mat-menu>
+
+        <mat-menu #addAllOnDemandMetadata="matMenu">
+          <div *ngIf="allProducts$ | async as products">
+            <button (click)="onCsvDownload(products)" mat-menu-item>
+              csv
+            </button>
+            <button (click)="onGeojsonDownload(products)" mat-menu-item>
+              geojson
+            </button>
+            <button (click)="onKmlDownload(products)" mat-menu-item>
+            kml
+          </button>
+        </div>
+        </mat-menu>
+
+        <mat-menu #addAllOnDemandData="matMenu">
+          <div *ngIf="allProducts$ | async as products">
+            <button (click)="onMakeDownloadScript(products)" mat-menu-item>
+              python (.py)
+            </button>
+            <button (click)="onMetalinkDownload(products)" mat-menu-item>
+            metalink
+          </button>
+        </div>
+        </mat-menu>
+
         <div class="button-tabs">
-          <button (click)="onSelectList()"
-                  [class.selected]="view === Views.LIST" mat-button>
+          <button
+            (click)="onSelectList()"
+            [class.selected]="view === Views.LIST"
+            mat-button
+          >
             Scenes
           </button>
-          <button (click)="onSelectDetail()"
-                  [class.selected]="view === Views.DETAIL" mat-button>
+          <button
+            (click)="onSelectDetail()"
+            [class.selected]="view === Views.DETAIL"
+            mat-button
+          >
             Scene Detail
           </button>
         </div>
-
       </div>
     </mat-card-subtitle>
 
@@ -103,25 +169,35 @@
     </div>
   </mat-card>
 
-
-  <mat-card *ngIf="view === Views.DETAIL" class="mp0 no-box-shadow" fxFlex="45" fxFlexFill>
+  <mat-card
+    *ngIf="view === Views.DETAIL"
+    class="mp0 no-box-shadow"
+    fxFlex="45"
+    fxFlexFill
+  >
     <mat-card-subtitle class="header medium-header">
       <div>
-        <button (click)="onSelectList()"
-         [class.selected]="view === Views.LIST" mat-button>
+        <button
+          (click)="onSelectList()"
+          [class.selected]="view === Views.LIST"
+          mat-button
+        >
           Scenes
         </button>
-        <button (click)="onSelectDetail()"
-         [class.selected]="view === Views.DETAIL" mat-button>
+        <button
+          (click)="onSelectDetail()"
+          [class.selected]="view === Views.DETAIL"
+          mat-button
+        >
           Scene Detail
         </button>
-<!--        <button (click)="onZoomToResults()" mat-icon-button>-->
-<!--          <mat-icon-->
-<!--            class="clickable noselect list-icon"-->
-<!--            matTooltip="Zoom to results">-->
-<!--              settings_overscan-->
-<!--          </mat-icon>-->
-<!--        </button>-->
+        <!--        <button (click)="onZoomToResults()" mat-icon-button>-->
+        <!--          <mat-icon-->
+        <!--            class="clickable noselect list-icon"-->
+        <!--            matTooltip="Zoom to results">-->
+        <!--              settings_overscan-->
+        <!--          </mat-icon>-->
+        <!--        </button>-->
       </div>
     </mat-card-subtitle>
 
@@ -129,12 +205,18 @@
   </mat-card>
 </ng-container>
 
-<mat-card class="mp0 no-box-shadow" [fxFlex]="breakpoint <= breakpoints.MEDIUM ? 55 : 45" fxFlexFill>
+<mat-card
+  class="mp0 no-box-shadow"
+  [fxFlex]="breakpoint <= breakpoints.MEDIUM ? 55 : 45"
+  fxFlexFill
+>
   <mat-card-subtitle
     [class.medium-header]="breakpoint <= breakpoints.MEDIUM"
-    class="header">
+    class="header"
+  >
     <div class="baseline-criteria-label" (click)="onToggleFiltersMenu()">
-      Baseline Criteria <div class="more-icon"><mat-icon>more_horiz</mat-icon></div>
+      Baseline Criteria
+      <div class="more-icon"><mat-icon>more_horiz</mat-icon></div>
     </div>
   </mat-card-subtitle>
   <app-baseline-chart></app-baseline-chart>

--- a/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
+++ b/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
@@ -2,11 +2,11 @@ import { Component, OnInit, Input, OnDestroy } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
-import { Store } from '@ngrx/store';
+import { Action, Store } from '@ngrx/store';
 import { AppState } from '@store';
 import * as uiStore from '@store/ui';
 
-import { Breakpoints } from '@models';
+import { AsfApiOutputFormat, Breakpoints } from '@models';
 import {ScreenSizeService, MapService, ScenesService, PairService} from '@services';
 
 import { SubSink } from 'subsink';
@@ -40,6 +40,7 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
   public searchType: models.SearchType;
 
   public sbasProducts: models.CMRProduct[];
+  public queuedProducts: models.CMRProduct[];
 
   public breakpoint: Breakpoints;
   public breakpoints = Breakpoints;
@@ -65,6 +66,13 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
         products => this.sbasProducts = products
       )
     );
+
+    this.subs.add(
+      this.store$.select(queueStore.getQueuedProducts).subscribe(
+        products => this.queuedProducts = products
+        )
+    );
+
   }
 
   public onZoomToResults(): void {
@@ -106,6 +114,49 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
       )
     );
   }
+
+      private clearDispatchRestoreQueue(queueStoreAction: Action,  products: models.CMRProduct[], currentQueue: models.CMRProduct[]): void {
+        this.store$.dispatch(new queueStore.ClearQueue());
+        this.store$.dispatch(new queueStore.AddItems(products));
+        this.store$.dispatch(queueStoreAction);
+
+        this.store$.dispatch(new queueStore.ClearQueue());
+        this.store$.dispatch(new queueStore.AddItems(currentQueue));
+      }
+
+      // TODO: Implement similar functionality to queue.component.ts
+      public onMakeDownloadScript(products: models.CMRProduct[]): void {
+        const currentQueue = this.queuedProducts;
+
+        this.clearDispatchRestoreQueue(new queueStore.MakeDownloadScript(), products, currentQueue);
+      }
+
+        // TODO: Implement similar functionality to queue.component.ts
+      public onCsvDownload(products: models.CMRProduct[]): void {
+        const currentQueue = this.queuedProducts;
+        this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.CSV), products, currentQueue);
+      }
+    
+        // TODO: Implement similar functionality to queue.component.ts
+      public onKmlDownload(products: models.CMRProduct[]): void {
+        const currentQueue = this.queuedProducts;
+        this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.KML), products, currentQueue);
+        // this.downloadMetadata(AsfApiOutputFormat.KML);
+      }
+    
+        // TODO: Implement similar functionality to queue.component.ts
+      public onGeojsonDownload(products: models.CMRProduct[]): void {
+        const currentQueue = this.queuedProducts;
+        this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.GEOJSON), products, currentQueue);
+        // this.downloadMetadata(AsfApiOutputFormat.GEOJSON);
+      }
+    
+        // TODO: Implement similar functionality to queue.component.ts
+      public onMetalinkDownload(products: models.CMRProduct[]): void {
+        const currentQueue = this.queuedProducts;
+        this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.METALINK), products, currentQueue);
+        // this.downloadMetadata(AsfApiOutputFormat.METALINK);
+      }
 
   public isExpired(job: models.Hyp3Job): boolean {
     return job.status_code === models.Hyp3JobStatusCode.SUCCEEDED &&

--- a/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
+++ b/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
@@ -115,48 +115,39 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
     );
   }
 
-      private clearDispatchRestoreQueue(queueStoreAction: Action,  products: models.CMRProduct[], currentQueue: models.CMRProduct[]): void {
-        this.store$.dispatch(new queueStore.ClearQueue());
-        this.store$.dispatch(new queueStore.AddItems(products));
-        this.store$.dispatch(queueStoreAction);
+    private clearDispatchRestoreQueue(queueStoreAction: Action,  products: models.CMRProduct[], currentQueue: models.CMRProduct[]): void {
+      this.store$.dispatch(new queueStore.ClearQueue());
+      this.store$.dispatch(new queueStore.AddItems(products));
+      this.store$.dispatch(queueStoreAction);
 
-        this.store$.dispatch(new queueStore.ClearQueue());
-        this.store$.dispatch(new queueStore.AddItems(currentQueue));
-      }
+      this.store$.dispatch(new queueStore.ClearQueue());
+      this.store$.dispatch(new queueStore.AddItems(currentQueue));
+    }
 
-      // TODO: Implement similar functionality to queue.component.ts
-      public onMakeDownloadScript(products: models.CMRProduct[]): void {
-        const currentQueue = this.queuedProducts;
+    public onMakeDownloadScript(products: models.CMRProduct[]): void {
+      const currentQueue = this.queuedProducts;
+      this.clearDispatchRestoreQueue(new queueStore.MakeDownloadScript(), products, currentQueue);
+    }
 
-        this.clearDispatchRestoreQueue(new queueStore.MakeDownloadScript(), products, currentQueue);
-      }
+    public onCsvDownload(products: models.CMRProduct[]): void {
+      const currentQueue = this.queuedProducts;
+      this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.CSV), products, currentQueue);
+    }
+  
+    public onKmlDownload(products: models.CMRProduct[]): void {
+      const currentQueue = this.queuedProducts;
+      this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.KML), products, currentQueue);
+    }
 
-        // TODO: Implement similar functionality to queue.component.ts
-      public onCsvDownload(products: models.CMRProduct[]): void {
-        const currentQueue = this.queuedProducts;
-        this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.CSV), products, currentQueue);
-      }
-    
-        // TODO: Implement similar functionality to queue.component.ts
-      public onKmlDownload(products: models.CMRProduct[]): void {
-        const currentQueue = this.queuedProducts;
-        this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.KML), products, currentQueue);
-        // this.downloadMetadata(AsfApiOutputFormat.KML);
-      }
-    
-        // TODO: Implement similar functionality to queue.component.ts
-      public onGeojsonDownload(products: models.CMRProduct[]): void {
-        const currentQueue = this.queuedProducts;
-        this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.GEOJSON), products, currentQueue);
-        // this.downloadMetadata(AsfApiOutputFormat.GEOJSON);
-      }
-    
-        // TODO: Implement similar functionality to queue.component.ts
-      public onMetalinkDownload(products: models.CMRProduct[]): void {
-        const currentQueue = this.queuedProducts;
-        this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.METALINK), products, currentQueue);
-        // this.downloadMetadata(AsfApiOutputFormat.METALINK);
-      }
+    public onGeojsonDownload(products: models.CMRProduct[]): void {
+      const currentQueue = this.queuedProducts;
+      this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.GEOJSON), products, currentQueue);
+    }
+  
+    public onMetalinkDownload(products: models.CMRProduct[]): void {
+      const currentQueue = this.queuedProducts;
+      this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.METALINK), products, currentQueue);
+    }
 
   public isExpired(job: models.Hyp3Job): boolean {
     return job.status_code === models.Hyp3JobStatusCode.SUCCEEDED &&

--- a/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
+++ b/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
@@ -133,7 +133,7 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
       const currentQueue = this.queuedProducts;
       this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.CSV), products, currentQueue);
     }
-  
+
     public onKmlDownload(products: models.CMRProduct[]): void {
       const currentQueue = this.queuedProducts;
       this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.KML), products, currentQueue);
@@ -143,7 +143,7 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
       const currentQueue = this.queuedProducts;
       this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.GEOJSON), products, currentQueue);
     }
-  
+
     public onMetalinkDownload(products: models.CMRProduct[]): void {
       const currentQueue = this.queuedProducts;
       this.clearDispatchRestoreQueue(new queueStore.DownloadMetadata(AsfApiOutputFormat.METALINK), products, currentQueue);


### PR DESCRIPTION
The baseline header menu now has a button that can now export its stack directly to a data/metadata file without having to add the stack to the download queue, and without changing the existing download queue.

Available downloadable formats match what's available in the download queue (GeoJSON, Kml,  Csv, Py, and metalink).