### PR TITLE
Add Baseline Stack Export Button to mobile view, add error catching to asfAPIQuery

### DIFF
--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
@@ -137,7 +137,7 @@
             </div>
           </div>
 
-          <div fxFlex="" class="list-button-group">
+          <div *ngIf="searchType === SearchTypes.BASELINE" fxFlex="" class="list-button-group">
             <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
               <label>Export</label>
             </div>

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -137,6 +137,12 @@ export class SearchEffects {
             }) :
             new SearchCanceled()
         ),
+        catchError(
+          _ => {
+            console.log(_);
+            return of(new SearchError(`Error loading search results`));
+          }
+        ),
       ))
     );
   }


### PR DESCRIPTION
Also removed stack export button from appearing in other menus.

Error catching in asfAPIQuery prevents searches hanging forever when searching for scenes without baselines via a baseline search (bug described in DS-3110). Now the search will end and gray out the search button.