### PR TITLE
Invalid Baseline Search fix and Baseline Export Stack Button fix

### DIFF
--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
@@ -137,7 +137,7 @@
             </div>
           </div>
 
-          <div fxFlex="" class="list-button-group">
+          <div *ngIf="searchType === SearchTypes.BASELINE" fxFlex="" class="list-button-group">
             <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
               <label>Export</label>
             </div>

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, Action } from '@ngrx/store';
 
-import { of, forkJoin, combineLatest, Observable } from 'rxjs';
+import { of, forkJoin, combineLatest, Observable, EMPTY } from 'rxjs';
 import { map, withLatestFrom, switchMap, catchError, filter } from 'rxjs/operators';
 
 import { AppState } from '../app.reducer';
@@ -22,6 +22,7 @@ import {
 import { getIsCanceled, getSearchType } from './search.reducer';
 
 import * as models from '@models';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Injectable()
 export class SearchEffects {
@@ -138,9 +139,11 @@ export class SearchEffects {
             new SearchCanceled()
         ),
         catchError(
-          _ => {
-            console.log(_);
-            return of(new SearchError(`Error loading search results`));
+          (err: HttpErrorResponse) => {
+            if (err.status !== 400) {
+              return of(new SearchError(`Uknown Error`));
+            }
+            return EMPTY;
           }
         ),
       ))

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -137,6 +137,12 @@ export class SearchEffects {
             }) :
             new SearchCanceled()
         ),
+        catchError(
+          _ => {
+            console.log(_);
+            return of(new SearchError(`Error loading search results`));
+          }
+        ),
       ))
     );
   }


### PR DESCRIPTION
After a failed api call when doing a Baseline/SBAS search for a product without a baseline the site will eventually stop loading and gray out the search button.

Fix bug where baseline export stack button appears with the wrong searchtype result header buttons.