### PR TITLE
Fixes Newline error in scenes service filtering

### DIFF
--- a/src/app/services/scenes.service.ts
+++ b/src/app/services/scenes.service.ts
@@ -33,7 +33,7 @@ export class ScenesService {
   ) { }
 
   public products$(): Observable<CMRProduct[]> {
-    return;
+    return (
       this.hideS1Raw$(
       this.hideExpired$(
       this.projectNameFilter$(
@@ -41,7 +41,8 @@ export class ScenesService {
       this.filterBaselineValues$(
       this.filterByDate$(
         this.store$.select(getAllProducts)
-      ))))));
+      ))))))
+    );
   }
 
   public scenes$(): Observable<CMRProduct[]> {


### PR DESCRIPTION
Fixes error introduced with On Demand Search Filtering caused by return statement that was followed by a newline.

This would cause products$ to return nothing and ignore the function calls on the following line.