### PR TITLE
On Demand Name filtering styling/bug fixes

### DIFF
--- a/src/app/components/filters-dropdown/custom-products-filters/custom-products-filters.component.html
+++ b/src/app/components/filters-dropdown/custom-products-filters/custom-products-filters.component.html
@@ -43,11 +43,15 @@
       </mat-panel-title>
     </mat-expansion-panel-header>
 
-    <div class="w100" style="display: flex; margin-top: 25px;">
-      <app-project-name-selector></app-project-name-selector>
-      <div class="w100" style="display: flex; width: 150px; margin-left: 25px;">
+    <div class="w100" style="display: flex; flex-wrap: wrap; margin-top: 25px;">
+      <!-- <div> -->
+      <app-project-name-selector style="margin-right: 25px;"></app-project-name-selector>
+    <!-- </div> -->
+      <!-- <div class="w100" style="display: flex;  margin-left: 25px;"> -->
+      <!-- <div> -->
        <app-job-product-name-selector></app-job-product-name-selector>
-      </div>
+      <!-- </div> -->
+      <!-- </div> -->
     </div>
 
     <div class="w100" style="display: flex; margin-top: 25px;">

--- a/src/app/components/filters-dropdown/custom-products-filters/custom-products-filters.component.html
+++ b/src/app/components/filters-dropdown/custom-products-filters/custom-products-filters.component.html
@@ -44,14 +44,8 @@
     </mat-expansion-panel-header>
 
     <div class="w100" style="display: flex; flex-wrap: wrap; margin-top: 25px;">
-      <!-- <div> -->
       <app-project-name-selector style="margin-right: 25px;"></app-project-name-selector>
-    <!-- </div> -->
-      <!-- <div class="w100" style="display: flex;  margin-left: 25px;"> -->
-      <!-- <div> -->
        <app-job-product-name-selector></app-job-product-name-selector>
-      <!-- </div> -->
-      <!-- </div> -->
     </div>
 
     <div class="w100" style="display: flex; margin-top: 25px;">

--- a/src/app/components/header/hyp3-header/hyp3-header.component.html
+++ b/src/app/components/header/hyp3-header/hyp3-header.component.html
@@ -10,11 +10,14 @@
       </app-project-name-selector>
 
       <div
-        *ngIf="breakpoint > breakpoints.SMALL"
-        fxFlex="300px"
-        class="breadcrumb">
-        <app-date-selector></app-date-selector>
+      *ngIf="breakpoint > breakpoints.SMALL"
+      fxFlex="300px"
+      class="breadcrumb">
+      <app-date-selector></app-date-selector>
       </div>
+
+      <app-job-product-name-selector *ngIf="breakpoint === breakpoints.FULL" class="breadcrumb">
+      </app-job-product-name-selector>
 
       <app-job-status-selector *ngIf="breakpoint === breakpoints.FULL" class="breadcrumb">
       </app-job-status-selector>

--- a/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.html
+++ b/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.html
@@ -2,5 +2,5 @@
     <mat-label>Product/Source Granule</mat-label>
     <input matInput placeholder="S1A..." 
     (input)="onFilterProductName($event.target.value)"
-    value="">
+    [value]="productNameFilter">
   </mat-form-field>

--- a/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.ts
+++ b/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.ts
@@ -1,9 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ScenesService } from '@services';
 import { SubSink } from 'subsink';
 
-import * as models from '@models';
-import * as filtersStore from '@store/filters';
+import * as filtersStore from '@store/filters'
 import { AppState } from '@store';
 import { Store } from '@ngrx/store';
 
@@ -14,22 +12,19 @@ import { Store } from '@ngrx/store';
 })
 export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
 
-  public jobs: models.CMRProduct[];
-
+  public productNameFilter: string;
   private subs = new SubSink();
 
   constructor(
-    private store$: Store<AppState>,
-    private scenesService: ScenesService,
+    private store$: Store<AppState>
   ) { }
 
   ngOnInit(): void {
     this.subs.add(
-      this.scenesService.scenes$().subscribe(
-        jobs => this.jobs = jobs
+      this.store$.select(filtersStore.getProductNameFilter).subscribe(
+        productNameFilter => this.productNameFilter = productNameFilter
       )
     );
-
   }
 
   public onFilterProductName(productName: string): void {

--- a/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.ts
+++ b/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { SubSink } from 'subsink';
 
-import * as filtersStore from '@store/filters'
+import * as filtersStore from '@store/filters';
 import { AppState } from '@store';
 import { Store } from '@ngrx/store';
 

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -52,6 +52,7 @@ export class SearchService {
       this.store$.dispatch(new filterStore.SetProjectName(''));
       this.store$.dispatch(new filterStore.SetJobStatuses([]));
       this.store$.dispatch(new filterStore.ClearDateRange());
+      this.store$.dispatch(new filterStore.SetProductNameFilter(''));
     }
   }
 


### PR DESCRIPTION
Adds line wrapping to On Demand Product Name filter field in filter menu on smaller screens. 

Product Name filter now appears in On Demand header when there is enough space available in the full desktop view.

Product name filter now clears when user clears their search.