### PR TITLE
DS-3500 Fix. This may have been fixed with work done on another task,…

### DIFF
--- a/src/app/components/shared/selectors/date-selector/date-selector.component.html
+++ b/src/app/components/shared/selectors/date-selector/date-selector.component.html
@@ -16,7 +16,7 @@
       class="clickable"
       name="startInput">
     <mat-datepicker-toggle matSuffix [for]="start"></mat-datepicker-toggle>
-    <mat-datepicker [startView]="!!startDate ? 'month' : 'multi-year'" #start></mat-datepicker>
+    <mat-datepicker touchUi="true" [startView]="!!startDate ? 'month' : 'multi-year'" #start></mat-datepicker>
   </mat-form-field>
 
   <mat-form-field class="date-input-field"
@@ -31,6 +31,6 @@
       matTooltip="Scene End Date (MM/DD/YYYY)"
       name="endInput">
     <mat-datepicker-toggle matSuffix [for]="end"></mat-datepicker-toggle>
-    <mat-datepicker [startView]="!!endDate ? 'month' : 'multi-year'" #end></mat-datepicker>
+    <mat-datepicker touchUi="true" [startView]="!!endDate ? 'month' : 'multi-year'" #end></mat-datepicker>
   </mat-form-field>
 </form>


### PR DESCRIPTION
DS-3500 Fix. This may have been fixed with work done on another task, however, I made the calendar an overlay modal instead of drop-down (up) on the input field. In mobile, it was cutting off half of the calendar control because the screen was too short and scrolling was blocked. This makes the calendar larger and always displayed in the center of the screen with everything thing else dimmed. It is easier for fingers to control and is always visible now.