### PR TITLE
Scene Add to On Demand Icon Mobile Scaling

### DIFF
--- a/src/app/components/results-menu/scenes-list/scene/scene.component.html
+++ b/src/app/components/results-menu/scenes-list/scene/scene.component.html
@@ -61,7 +61,7 @@
 
         <mat-icon
           *ngIf="!!hyp3ableByJobType && hyp3ableByJobType.total > 0"
-          class="icon-margin"
+          class="icon-margin mobile-svg"
           [matMenuTriggerFor]="sceneAdd.addMenu"
           [matMenuTriggerData]="{ hyp3able: hyp3ableByJobType.byJobType }"
           svgIcon="hyp3">
@@ -84,11 +84,11 @@
         <span class="number-queued"> {{ numQueued }} </span>
       </div>
 
-      <div *ngIf="searchType === SearchTypes.CUSTOM_PRODUCTS" style="margin-right: 10px;">
+      <div *ngIf="searchType === SearchTypes.CUSTOM_PRODUCTS" style="margin-right: 10px;" [ngClass]="{'mobile-size': breakpoint <= breakpoints.SMALL}">
       <mat-icon *ngIf="isExpired(scene.metadata.job)"
         [matMenuTriggerFor]="sceneAdd.addMenu"
         [matMenuTriggerData]="{ hyp3able: getExpiredHyp3ableObject().byJobType }"
-        class="icon-margin"
+        class="icon-margin mobile-svg"
         svgIcon="hyp3">
       </mat-icon>
       </div>
@@ -112,7 +112,7 @@
               <mat-icon *ngIf="hyp3ableByJobType.total > 0"
                 [matMenuTriggerFor]="sceneAdd.addMenu"
                 [matMenuTriggerData]="{ hyp3able: hyp3ableByJobType.byJobType }"
-                class="icon-margin"
+                class="icon-margin mobile-svg"
                 svgIcon="hyp3">
               </mat-icon>
               <mat-icon *ngIf="isDownloadable(scene)"

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.scss
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.scss
@@ -91,6 +91,11 @@
   font-size: 14px;
 }
 
+.mobile-size .icon-margin.mobile-svg {
+  height: 14px;
+  margin-left: 10px;
+}
+
 .mobile-size .mat-list-base .mat-list-item {
   font-size: 14px;
 }


### PR DESCRIPTION
fixes mobile add On Demand Button svg icon scaling in scenes list results for Geographic, Baseline, and On Demand searches. 

Cause: On Demand Button's icon is an svg, so scaling needs to be done manually
Solution: Added a mobile-svg class in scenes-list.scss for mat-icons with svg sources