### PR TITLE
DS-3876 small frame search bug

### DIFF
--- a/src/app/components/shared/selectors/path-selector/path-selector.component.html
+++ b/src/app/components/shared/selectors/path-selector/path-selector.component.html
@@ -2,6 +2,7 @@
   <mat-form-field *ngIf="prop.isRelevant(p.PATH)"
     [class.invalid-input-animation]="typeHasError(inputTypes.PATH_START)">
     <input matInput
+      type="number"
       (input)="onValueChanged($event, inputTypes.PATH_START)"
       [(ngModel)]="pathStart"
       name="pathStart" placeholder="Path Start">
@@ -9,6 +10,7 @@
   <mat-form-field *ngIf="prop.isRelevant(p.PATH)" class="range-form-input"
     [class.invalid-input-animation]="typeHasError(inputTypes.PATH_END)">
     <input matInput
+      type="number"
       (input)="onValueChanged($event, inputTypes.PATH_END)"
       [(ngModel)]="pathEnd"
       name="pathEnd" placeholder="Path End">
@@ -17,6 +19,7 @@
   <mat-form-field *ngIf="prop.isRelevant(p.FRAME)"
     [class.invalid-input-animation]="typeHasError(inputTypes.FRAME_START)">
     <input matInput
+      type="number"
       (input)="onValueChanged($event, inputTypes.FRAME_START)"
       [(ngModel)]="frameStart"
       name="frameStart" placeholder="Frame Start">
@@ -24,6 +27,7 @@
   <mat-form-field *ngIf="prop.isRelevant(p.FRAME)" class="range-form-input"
     [class.invalid-input-animation]="typeHasError(inputTypes.FRAME_END)">
     <input matInput
+      type="number"
       (input)="onValueChanged($event, inputTypes.FRAME_END)"
       [(ngModel)]="frameEnd"
       name="frameEnd" placeholder="Frame End">

--- a/src/app/components/shared/selectors/path-selector/path-selector.component.scss
+++ b/src/app/components/shared/selectors/path-selector/path-selector.component.scss
@@ -11,6 +11,7 @@
 }
 
 // Hides input field up/down arrows
+
 /* Chrome, Safari, Edge, Opera */
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {

--- a/src/app/components/shared/selectors/path-selector/path-selector.component.scss
+++ b/src/app/components/shared/selectors/path-selector/path-selector.component.scss
@@ -9,3 +9,16 @@
 .range-form-input {
   margin-right: 10px;
 }
+
+// Hides input field up/down arrows
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type=number] {
+  -moz-appearance: textfield;
+}

--- a/src/app/components/shared/selectors/path-selector/path-selector.component.ts
+++ b/src/app/components/shared/selectors/path-selector/path-selector.component.ts
@@ -95,18 +95,14 @@ export class PathSelectorComponent implements OnInit, OnDestroy {
   }
 
   public onValueChanged(event: Event, inputType: PathFormInputType): void {
+    const inputValue = (event.target as HTMLInputElement).valueAsNumber;
+
     let val: number | null;
 
-    const inputValue = (event.target as HTMLInputElement).value;
-
     if (!this.isValidNumber(inputValue)) {
-      if (inputValue !== '') {
-        this.inputErrors$.next(inputType);
-      }
-
       val = null;
     } else {
-      val = +inputValue;
+      val = inputValue;
     }
 
     const action = this.getActionFor(inputType, val);
@@ -124,8 +120,8 @@ export class PathSelectorComponent implements OnInit, OnDestroy {
     return new ActionType(val);
   }
 
-  private isValidNumber(val: string): boolean {
-    return !!val && !isNaN(+val) && (+val) >= 0;
+  private isValidNumber(val: number): boolean {
+    return !!val && !isNaN(val) && val >= 0;
   }
 
   public onNewOmitPolygon(e): void {

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -102,4 +102,10 @@ export class NotificationService {
   public error(message: string, title = '', options = {}): ActiveToast<any> {
     return this.toastr.warning(message, title, {...options, ...this.toastOptions});
   }
+
+  public rawDataAutoToggle() {
+    const title = 'Showing Raw Results';
+    const message = 'Only raw results found. Select different file types in the filters menu, or increase max search results';
+    this.toastr.info(message, title);
+  }
 }

--- a/src/app/services/scenes.service.ts
+++ b/src/app/services/scenes.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Observable, combineLatest } from 'rxjs';
 import { debounceTime, map } from 'rxjs/operators';
 import * as moment from 'moment';
-
+import * as uiStore from '@store/ui';
 import { Store } from '@ngrx/store';
 import { AppState } from '@store/app.reducer';
 import {
@@ -22,6 +22,7 @@ import {
   Range, ColumnSortDirection,
   Hyp3Job, Hyp3JobStatusCode
 } from '@models';
+import { NotificationService } from './notification.service';
 
 @Injectable({
   providedIn: 'root'
@@ -29,6 +30,7 @@ import {
 export class ScenesService {
   constructor(
     private store$: Store<AppState>,
+    private notificationService: NotificationService,
   ) { }
 
   public products$(): Observable<CMRProduct[]> {
@@ -111,7 +113,13 @@ export class ScenesService {
           return scenes;
         }
 
-        return scenes.filter(scene => !scene.productTypeDisplay.includes('RAW'));
+        const filteredScenes = scenes.filter(scene => !scene.productTypeDisplay.includes('RAW'));
+
+        if(filteredScenes.length === 0 && scenes.length > 0) {
+          this.store$.dispatch(new uiStore.ShowS1RawData);
+          this.notificationService.rawDataAutoToggle();
+        }
+        return filteredScenes;
       })
     );
   }

--- a/src/app/services/scenes.service.ts
+++ b/src/app/services/scenes.service.ts
@@ -115,7 +115,7 @@ export class ScenesService {
 
         const filteredScenes = scenes.filter(scene => !scene.productTypeDisplay.includes('RAW'));
 
-        if(filteredScenes.length === 0 && scenes.length > 0) {
+        if (filteredScenes.length === 0 && scenes.length > 0) {
           this.store$.dispatch(new uiStore.ShowS1RawData);
           this.notificationService.rawDataAutoToggle();
         }


### PR DESCRIPTION
The bug was not actually a bug, just misleading default behavior. The first 250 search results were all raw data which was hidden because raw data visibility is toggled to off by default.

Raw data is now automatically toggled on be visible when search results would otherwise be empty, and a toast notification is fired to inform the user of the toggle and why.