### PR TITLE
Event Monitoring url state + Product List Selection Pins

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -408,6 +408,8 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
       return !searchState.filters.filterMaster;
     } else if (searchState.searchType === models.SearchType.SBAS) {
       return !searchState.filters.reference;
+    } else if (searchState.searchType === models.SearchType.SARVIEWS_EVENTS) {
+      return searchState.filters.selectedEventID !== '';
     }
 
     return false;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -445,6 +445,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
   public onClearSearch(): void {
     this.store$.dispatch(new scenesStore.ClearScenes());
+    this.store$.dispatch(new scenesStore.SetSelectedSarviewsEvent(''));
     this.store$.dispatch(new uiStore.CloseResultsMenu());
 
     this.searchService.clear(this.searchType);

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -7,6 +7,7 @@ import { Observable, combineLatest } from 'rxjs';
 import {
   map, filter, switchMap, tap,
   withLatestFrom,
+  debounceTime,
 } from 'rxjs/operators';
 
 import { Vector as VectorLayer} from 'ol/layer';
@@ -98,6 +99,7 @@ export class MapComponent implements OnInit, OnDestroy  {
     this.subs.add(
     this.store$.select(getSelectedSarviewsEvent).pipe(
       filter(event => !!event),
+      debounceTime(200),
     ).subscribe( event => {
       const point = this.mapService.getEventCoordinate(event.event_id);
       const coords = point.getCoordinates();

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.html
@@ -1,4 +1,5 @@
-<cdk-virtual-scroll-viewport orientation="horizontal" *ngIf="(searchType$ | async) !== searchTypes.SARVIEWS_EVENTS;" class="browse-list-viewport w100 h100" itemSize="140">
+<ng-container fxFlex class="browse-list" *ngIf="searchtype !== searchTypes.SARVIEWS_EVENTS; else sarviewsScroll">
+<cdk-virtual-scroll-viewport orientation="horizontal" class="browse-list-viewport w100 h100" itemSize="140">
   <div *cdkVirtualFor="let scene of (scenes$ | async)"
     (click)="onNewSceneSelected(scene)"
     [class.selected]="scene.id === selectedId"
@@ -18,9 +19,10 @@
   </div>
 
 </cdk-virtual-scroll-viewport>
+</ng-container>
 
-
-<cdk-virtual-scroll-viewport orientation="horizontal" *ngIf="(searchType$ | async) === searchTypes.SARVIEWS_EVENTS && !!sarviewsProducts" class="browse-list-viewport w100 h100" itemSize="140" #sarviewsScroll>
+<ng-template fxFlex class="browse-list" #sarviewsScroll>
+<cdk-virtual-scroll-viewport orientation="horizontal" class="browse-list-viewport w100 h100" itemSize="140" >
 <div *cdkVirtualFor="let product of sarviewsProducts"
 (click)="onNewProductSelected(product)"
 [class.selected]="product.product_id === selectedProductId"
@@ -37,3 +39,4 @@ class="clickable">
 </div>
 </div>
 </cdk-virtual-scroll-viewport>
+</ng-template>

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.html
@@ -1,5 +1,5 @@
-<ng-container fxFlex class="browse-list" *ngIf="searchtype !== searchTypes.SARVIEWS_EVENTS; else sarviewsScroll">
-<cdk-virtual-scroll-viewport orientation="horizontal" class="browse-list-viewport w100 h100" itemSize="140">
+<ng-container class="browse-list" *ngIf="searchtype !== searchTypes.SARVIEWS_EVENTS; else sarviewsScroll">
+<cdk-virtual-scroll-viewport style="height: 150px;" orientation="horizontal" class="browse-list-viewport w100 h100" itemSize="140">
   <div *cdkVirtualFor="let scene of (scenes$ | async)"
     (click)="onNewSceneSelected(scene)"
     [class.selected]="scene.id === selectedId"
@@ -21,8 +21,8 @@
 </cdk-virtual-scroll-viewport>
 </ng-container>
 
-<ng-template fxFlex class="browse-list" #sarviewsScroll>
-<cdk-virtual-scroll-viewport orientation="horizontal" class="browse-list-viewport w100 h100" itemSize="140" >
+<ng-template class="browse-list" #sarviewsScroll>
+<cdk-virtual-scroll-viewport style="height: 150px;" orientation="horizontal" class="browse-list-viewport w100 h100" itemSize="140" >
 <div *cdkVirtualFor="let product of sarviewsProducts"
 (click)="onNewProductSelected(product)"
 [class.selected]="product.product_id === selectedProductId"

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
@@ -4,6 +4,14 @@
 
 $config: mat.define-typography-config();
 
+.browse-list {
+  min-height: 140px;
+  border-top-color: $asf-primary-dark;
+  border-top-style: solid;
+  border-top-width: 1px;
+  background-color: $asf-primary-light;
+}
+
 .browse-list-viewport .cdk-virtual-scroll-content-wrapper {
   display: flex;
   flex-direction: row;
@@ -37,12 +45,4 @@ $config: mat.define-typography-config();
   height: 18px;
   font-size: small;
   margin-bottom: 5px;
-}
-
-.browse-list {
-  min-height: 140px;
-  border-top-color: $asf-primary-dark;
-  border-top-style: solid;
-  border-top-width: 1px;
-  background-color: $asf-primary-light;
 }

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
@@ -1,3 +1,9 @@
+@use '~@angular/material' as mat;
+
+@import "asf-theme";
+
+$config: mat.define-typography-config();
+
 .browse-list-viewport .cdk-virtual-scroll-content-wrapper {
   display: flex;
   flex-direction: row;
@@ -31,4 +37,12 @@
   height: 18px;
   font-size: small;
   margin-bottom: 5px;
+}
+
+.browse-list {
+  min-height: 140px;
+  border-top-color: $asf-primary-dark;
+  border-top-style: solid;
+  border-top-width: 1px;
+  background-color: $asf-primary-light;
 }

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
@@ -1,6 +1,6 @@
+@use '~@angular/material' as mat;
 @import "asf-theme";
 
-@use '~@angular/material' as mat;
 
 $config: mat.define-typography-config();
 

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
@@ -1,6 +1,5 @@
-@use '~@angular/material' as mat;
-
 @import "asf-theme";
+@use '~@angular/material' as mat;
 
 $config: mat.define-typography-config();
 

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
@@ -1,4 +1,5 @@
 @import "asf-theme";
+
 @use '~@angular/material' as mat;
 
 $config: mat.define-typography-config();

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
@@ -1,6 +1,6 @@
 @use '~@angular/material' as mat;
-@import "asf-theme";
 
+@import "asf-theme";
 
 $config: mat.define-typography-config();
 

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.scss
@@ -1,8 +1,4 @@
-@use '~@angular/material' as mat;
 @import "asf-theme";
-
-
-$config: mat.define-typography-config();
 
 .browse-list {
   min-height: 140px;

--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.ts
@@ -3,7 +3,7 @@ import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { SubSink } from 'subsink';
 
 import { Observable } from 'rxjs';
-import { map, filter, withLatestFrom, tap, switchMap } from 'rxjs/operators';
+import { map, filter, withLatestFrom, tap, switchMap, debounceTime } from 'rxjs/operators';
 
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
@@ -30,11 +30,14 @@ export class BrowseListComponent implements OnInit, AfterViewInit, OnDestroy {
   public scenes$: Observable<models.CMRProduct[]>;
   public selectedId: string;
   public browses$ = this.store$.select(scenesStore.getSelectedSceneBrowses);
-  public sarviewsProducts$ = this.store$.select(scenesStore.getSelectedSarviewsEventProducts);
-  public sarviewsProducts: models.SarviewsProduct[] = [];
+  public sarviewsProducts$ = this.store$.select(scenesStore.getSelectedSarviewsEventProducts).pipe(
+    filter(products => !!products),
+    debounceTime(500));
+  public sarviewsProducts: models.SarviewsProduct[];
   public selectedProductId: string;
 
   public searchType$ = this.store$.select(searchStore.getSearchType);
+  public searchtype;
   public searchTypes = models.SearchType;
 
   public productBrowseStates: {[product_id in string]: PinnedProduct} = {};
@@ -75,6 +78,11 @@ export class BrowseListComponent implements OnInit, AfterViewInit, OnDestroy {
       )
     );
 
+    this.subs.add(
+      this.searchType$.subscribe(
+        searchtype => this.searchtype = searchtype
+      )
+    );
   }
 
   ngAfterViewInit() {

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -1,5 +1,4 @@
 <div class="browse-dialog"
-     *ngIf="breakpoint$ | async as breakpoint"
     >
     <div *ngIf="(searchType$ | async) !== searchTypes.SARVIEWS_EVENTS">
       <div *ngIf="scene$ | async as scene" fxLayout="row" class="dialog-header--layout">

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -195,7 +195,7 @@
 
   <ng-container *ngIf="breakpoint > breakpoints.MOBILE">
       <div>
-      <app-browse-list fxFlex class="browse-list"></app-browse-list>
+      <app-browse-list style="height: 150px;"></app-browse-list>
     </div>
   </ng-container>
 

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -129,12 +129,12 @@
           <ng-container>
             <div class="detail-header">Event Details</div>
             <ul style="columns: 1; font-size: 12px;">
-              <li *ngIf="sarviewsEvent">{{sarviewsEvent.event_type === 'quake'
+              <li *ngIf="!!sarviewsEvent">{{sarviewsEvent.event_type === 'quake'
                 ? 'usgs id: ' + (sarviewsEvent | quakeEvent).usgs_event_id
                 : 'smithsonian id: ' + (sarviewsEvent | volcanicEvent).smithsonian_event_id}}
                  </li>
                  <li>
-                  description: {{sarviewsEvent.description}}
+                  description: {{sarviewsEvent?.description}}
                  </li>
             </ul>
 

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -58,7 +58,7 @@
       <div *ngIf="(searchType$ | async) === searchTypes.SARVIEWS_EVENTS">
       <button
       style="position: absolute; bottom: 5px; right: 20%; margin: 15px; min-width: 200px; border-radius: 4px !important;"
-      mat-flat-button (click)="OpenProductInSarviews()">Open Product In SARViews</button>
+      mat-flat-button (click)="OpenProductInSarviews()">Open Pinned Products In SARViews</button>
     </div>
     <div *ngIf="isImageLoading" color="accent" class="browse-map--overlay">
       <mat-spinner></mat-spinner>

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
@@ -323,7 +323,7 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public OpenProductInSarviews() {
-    const url = this.sarviewsService.getSarviewsEventPinnedUrl(this.sarviewsEvent.event_id, [this.currentSarviewsProduct.product_id]);
+    const url = this.sarviewsService.getSarviewsEventPinnedUrl(this.sarviewsEvent.event_id, [...Object.keys(this.pinnedProducts).filter(key => this.pinnedProducts[key].isPinned)]);
     window.open(url);
   }
 

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
@@ -76,7 +76,7 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
       this.breakpoint$.subscribe(
         breakpoint => this.breakpoint = breakpoint
       )
-    )
+    );
     this.subs.add(
       this.store$.select(scenesStore.getSelectedSceneProducts).subscribe(
         products => {
@@ -221,7 +221,7 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
       ).subscribe(_ =>
         this.setPinnedProducts()
       )
-    )
+    );
   }
 
   private loadBrowseImage(scene: models.CMRProduct, browse): void {
@@ -340,6 +340,6 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnDestroy() {
     this.subs.unsubscribe();
-    this.store$.dispatch(new uiStore.SetIsBrowseDialogOpen(false))
+    this.store$.dispatch(new uiStore.SetIsBrowseDialogOpen(false));
   }
 }

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
@@ -2,7 +2,9 @@ import { Component, OnInit, AfterViewInit, OnDestroy } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { SubSink } from 'subsink';
 
-import { filter, map, tap, debounceTime, first, distinctUntilChanged, delay, withLatestFrom } from 'rxjs/operators';
+import { filter, map, tap, debounceTime, first,
+  // distinctUntilChanged,
+  delay, withLatestFrom } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
 import { AppState } from '@store';
@@ -14,7 +16,9 @@ import * as searchStore from '@store/search';
 import * as models from '@models';
 import { BrowseMapService, DatasetForProductService, SarviewsEventsService } from '@services';
 import * as services from '@services/index';
-import { SarviewProductGranule, SarviewsProduct } from '@models';
+import {
+  // Breakpoints,
+  SarviewProductGranule, SarviewsProduct } from '@models';
 import { ClipboardService } from 'ngx-clipboard';
 import { MatSliderChange } from '@angular/material/slider';
 import { PinnedProduct } from '@services/browse-map.service';
@@ -47,8 +51,9 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
   public currentBrowse = null;
   public paramsList: any;
 
-  public breakpoint$ = this.screenSize.breakpoint$.pipe(distinctUntilChanged((a, b) => a === b));
+  public breakpoint$ = this.screenSize.breakpoint$;
   public breakpoints = models.Breakpoints;
+  public breakpoint: models.Breakpoints = models.Breakpoints.FULL;
 
   private image: HTMLImageElement = new Image();
   private subs = new SubSink();
@@ -67,6 +72,11 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
   ) { }
 
   ngOnInit() {
+    this.subs.add(
+      this.breakpoint$.subscribe(
+        breakpoint => this.breakpoint = breakpoint
+      )
+    )
     this.subs.add(
       this.store$.select(scenesStore.getSelectedSceneProducts).subscribe(
         products => {

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
@@ -198,6 +198,7 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
         filter(([_, searchtype]) => searchtype === models.SearchType.SARVIEWS_EVENTS),
         map(([products, _]) => products),
         filter(products => !!products),
+        filter(products => products.length > 0),
         debounceTime(500),
         first(),
       ).subscribe(

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
@@ -23,7 +23,7 @@ import { PinnedProduct } from '@services/browse-map.service';
   selector: 'app-image-dialog',
   templateUrl: './image-dialog.component.html',
   styleUrls: ['./image-dialog.component.scss'],
-  providers: [ BrowseMapService ]
+  // providers: [ BrowseMapService ]
 })
 export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
   public scene$ = this.store$.select(scenesStore.getSelectedScene);
@@ -329,5 +329,6 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnDestroy() {
     this.subs.unsubscribe();
+    this.store$.dispatch(new uiStore.SetIsBrowseDialogOpen(false))
   }
 }

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
@@ -23,7 +23,7 @@ import { PinnedProduct } from '@services/browse-map.service';
   selector: 'app-image-dialog',
   templateUrl: './image-dialog.component.html',
   styleUrls: ['./image-dialog.component.scss'],
-  // providers: [ BrowseMapService ]
+  providers: [ BrowseMapService ]
 })
 export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
   public scene$ = this.store$.select(scenesStore.getSelectedScene);

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
@@ -323,7 +323,10 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public OpenProductInSarviews() {
-    const url = this.sarviewsService.getSarviewsEventPinnedUrl(this.sarviewsEvent.event_id, [...Object.keys(this.pinnedProducts).filter(key => this.pinnedProducts[key].isPinned)]);
+    const url = this.sarviewsService.getSarviewsEventPinnedUrl(
+        this.sarviewsEvent.event_id,
+        [...Object.keys(this.pinnedProducts).filter(key => this.pinnedProducts[key].isPinned)]
+      );
     window.open(url);
   }
 

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -213,7 +213,7 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
       return;
     }
 
-    if(this.searchType === models.SearchType.SARVIEWS_EVENTS) {
+    if (this.searchType === models.SearchType.SARVIEWS_EVENTS) {
       this.store$.dispatch(new scenesStore.SetSelectedSarviewProduct(this.sarviewsProducts[this.browseIndex]));
     }
     this.store$.dispatch(new uiStore.SetIsBrowseDialogOpen(true));

--- a/src/app/components/results-menu/scene-files/scene-files.component.html
+++ b/src/app/components/results-menu/scene-files/scene-files.component.html
@@ -31,10 +31,10 @@
         <fa-icon [icon]="copyIcon"></fa-icon> Copy All Scenes to Clipboard
         </div>
       </button>
-      <button class="mat-flat-button mat-primary" style="border-radius: 4px !important;" color="primary" mat-flat-button (click)="onOpenPinnedProducts(selectedSarviewEventID)">
+      <button class="mat-flat-button mat-primary" style="border-radius: 4px !important;" color="primary" mat-flat-button (click)="onOpenPinnedProducts()">
         <div class="sarviews-button-display">
-          <mat-icon>web</mat-icon>
-          View Selected on SARViews
+          <!-- <mat-icon>web</mat-icon> -->
+          View Selected on Map
         </div>
       </button>
     </div>

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -19,6 +19,7 @@ import * as moment from 'moment';
 
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { MatSelectionListChange } from '@angular/material/list';
+import { PinnedProduct } from '@services/browse-map.service';
 
 @Component({
   selector: 'app-scene-files',
@@ -253,6 +254,19 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
 
   public onSelectSarviewsProduct(selections: MatSelectionListChange) {
     selections.options.forEach(option => this.selectedProducts[option.value] = option.selected );
+    const pinned = Object.keys(this.selectedProducts).reduce(
+      (prev, key) => {
+        let output = {} as PinnedProduct;
+        output.isPinned = this.selectedProducts[key];
+        const sarviewsProduct = this.sarviewsProducts.find(prod => prod.product_id === key)
+        output.url = sarviewsProduct.files.product_url;
+        output.wkt = sarviewsProduct.granules[0].wkt;
+
+        prev[key] = output;
+        return prev;
+      }, {} as {[product_id in string]: PinnedProduct}
+    )
+    this.store$.dispatch(new scenesStore.SetImageBrowseProducts(pinned));
     // this.selectedProducts[product_id] = !this.selectedProducts?.[product_id] ?? true;
   }
 

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -161,7 +161,7 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
           Object.keys(this.selectedProducts).forEach(id => delete this.selectedProducts[id]);
           products.forEach(prod => this.selectedProducts[prod.product_id] = pinned_browse_ids.includes(prod.product_id));
 
-          if(pinned_browse_ids.length > 0) {
+          if(pinned_browse_ids.length > 0 && products.length > 0) {
             if(!this.selectedProducts[pinned_browse_ids[0]]) {
               this.onUpdatePinnedUrl();
             }

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -170,31 +170,10 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
               this.onUpdatePinnedUrl();
             }
           }
-          // this.selectedProducts = val.map(product => product.product_id).reduce((prev, curr) => {
-          //   prev[curr] = browse_ids.includes(curr);
-          //   return prev;
-          // }, {} as {[product_id in string]: boolean});
 
         }
       )
     );
-
-    // this.subs.add(
-    //   this.store$.select(scenesStore.getPinnedEventBrowseIDs).pipe(skip(1)).subscribe(
-    //     pinnedIDs => {
-    //       if(!this.selectedProducts[pinnedIDs?.[0]] && pinnedIDs.length > 0) {
-    //         this.onUpdatePinnedUrl();
-    //         // this.store$.dispatch(new scenesStore.SetImageBrowseProducts(this.selectedProducts));
-    //       } else {
-    //       // const pinnedObj = pinnedIDs.reduce((prev, curr) => prev[curr] = true, {});
-    //         Object.keys(this.selectedProducts).forEach(
-    //           id => this.selectedProducts[id] = pinnedIDs.includes(id)
-    //         );
-    //       }
-    //       // this.selectedProducts = { ...this.selectedProducts, ...pinnedObj}
-    //     }
-    //   )
-    // )
 
     this.subs.add(
       this.selectedSarviewsEventID$.subscribe(

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -165,8 +165,8 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
           Object.keys(this.selectedProducts).forEach(id => delete this.selectedProducts[id]);
           products.forEach(prod => this.selectedProducts[prod.product_id] = pinned_browse_ids.includes(prod.product_id));
 
-          if(pinned_browse_ids.length > 0 && products.length > 0) {
-            if(!this.selectedProducts[pinned_browse_ids[0]]) {
+          if (pinned_browse_ids.length > 0 && products.length > 0) {
+            if (!this.selectedProducts[pinned_browse_ids[0]]) {
               this.onUpdatePinnedUrl();
             }
           }
@@ -258,7 +258,7 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
   public currentPinnedUrl(current_id: string): string {
     const product_ids = Object.keys(this.selectedProducts).filter(
       product_id => !!this.selectedProducts?.[product_id]
-    )
+    );
 
     return this.sarviewsService.getSarviewsEventPinnedUrl(current_id, product_ids);
   }
@@ -272,9 +272,9 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
   public onUpdatePinnedUrl() {
     const pinned = Object.keys(this.selectedProducts).reduce(
       (prev, key) => {
-        let output = {} as PinnedProduct;
+        const output = {} as PinnedProduct;
         output.isPinned = this.selectedProducts[key];
-        const sarviewsProduct = this.sarviewsProducts.find(prod => prod.product_id === key)
+        const sarviewsProduct = this.sarviewsProducts.find(prod => prod.product_id === key);
         output.url = sarviewsProduct.files.product_url;
         output.wkt = sarviewsProduct.granules[0].wkt;
 

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy, AfterContentInit } from '@angular/core';
 import { SubSink } from 'subsink';
 
 import { combineLatest } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, map, withLatestFrom } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, map, skip, withLatestFrom } from 'rxjs/operators';
 
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
@@ -170,7 +170,7 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
     );
 
     this.subs.add(
-      this.store$.select(scenesStore.getPinnedEventBrowseIDs).subscribe(
+      this.store$.select(scenesStore.getPinnedEventBrowseIDs).pipe(skip(1)).subscribe(
         pinnedIDs => {
           if(!this.selectedProducts[pinnedIDs?.[0]] && pinnedIDs.length > 0) {
             this.onUpdatePinnedUrl();

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -156,17 +156,30 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
         distinctUntilChanged((a, b) => a[0]?.event_id === b[0]?.event_id),
         withLatestFrom(this.store$.select(scenesStore.getPinnedEventBrowseIDs))
         ).subscribe(
-        ([val, browse_ids]) => {
-          this.sarviewsProducts = val;
-          this.selectedProducts = {};
-          this.selectedProducts = val.map(product => product.product_id).reduce((prev, curr) => {
-            prev[curr] = browse_ids.includes(curr);
-            return prev;
-          }, {} as {[product_id in string]: boolean});
+        ([products, pinned_browse_ids]) => {
+          this.sarviewsProducts = products;
+          Object.keys(this.selectedProducts).forEach(id => delete this.selectedProducts[id]);
+          products.forEach(prod => this.selectedProducts[prod.product_id] = pinned_browse_ids.includes(prod.product_id));
+          // this.selectedProducts = val.map(product => product.product_id).reduce((prev, curr) => {
+          //   prev[curr] = browse_ids.includes(curr);
+          //   return prev;
+          // }, {} as {[product_id in string]: boolean});
 
         }
       )
     );
+
+    this.subs.add(
+      this.store$.select(scenesStore.getPinnedEventBrowseIDs).subscribe(
+        pinnedIDs => {
+          // const pinnedObj = pinnedIDs.reduce((prev, curr) => prev[curr] = true, {});
+          Object.keys(this.selectedProducts).forEach(
+            id => this.selectedProducts[id] = pinnedIDs.includes(id)
+          );
+          // this.selectedProducts = { ...this.selectedProducts, ...pinnedObj}
+        }
+      )
+    )
 
     this.subs.add(
       this.selectedSarviewsEventID$.subscribe(

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -172,10 +172,15 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
     this.subs.add(
       this.store$.select(scenesStore.getPinnedEventBrowseIDs).subscribe(
         pinnedIDs => {
+          if(!this.selectedProducts[pinnedIDs?.[0]] && pinnedIDs.length > 0) {
+            this.onUpdatePinnedUrl();
+            // this.store$.dispatch(new scenesStore.SetImageBrowseProducts(this.selectedProducts));
+          } else {
           // const pinnedObj = pinnedIDs.reduce((prev, curr) => prev[curr] = true, {});
-          Object.keys(this.selectedProducts).forEach(
-            id => this.selectedProducts[id] = pinnedIDs.includes(id)
-          );
+            Object.keys(this.selectedProducts).forEach(
+              id => this.selectedProducts[id] = pinnedIDs.includes(id)
+            );
+          }
           // this.selectedProducts = { ...this.selectedProducts, ...pinnedObj}
         }
       )

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -10,6 +10,7 @@ import * as scenesStore from '@store/scenes';
 import * as queueStore from '@store/queue';
 import * as userStore from '@store/user';
 import * as hyp3Store from '@store/hyp3';
+import * as uiStore from '@store/ui';
 
 import { Hyp3Service, NotificationService, SarviewsEventsService } from '@services';
 import * as models from '@models';
@@ -20,6 +21,8 @@ import * as moment from 'moment';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { MatSelectionListChange } from '@angular/material/list';
 import { PinnedProduct } from '@services/browse-map.service';
+import { ImageDialogComponent } from '../scene-detail/image-dialog';
+import { MatDialog } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-scene-files',
@@ -89,6 +92,7 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
     private sarviewsService: SarviewsEventsService,
     private clipboard: ClipboardService,
     private notificationService: NotificationService,
+    public dialog: MatDialog,
   ) { }
 
   ngOnInit() {
@@ -303,8 +307,26 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
     this.store$.dispatch(new scenesStore.SetImageBrowseProducts(pinned));
   }
 
-  public onOpenPinnedProducts(current_id: string) {
-    window.open(this.currentPinnedUrl(current_id));
+  public onOpenPinnedProducts() {
+    // if(this.searchType === models.SearchType.SARVIEWS_EVENTS) {
+      this.store$.dispatch(new scenesStore.SetSelectedSarviewProduct(this.sarviewsProducts[0]));
+    // }
+    this.store$.dispatch(new uiStore.SetIsBrowseDialogOpen(true));
+
+    const dialogRef = this.dialog.open(ImageDialogComponent, {
+      width: '99%',
+      maxWidth: '99%',
+      height: '99%',
+      maxHeight: '99%',
+      panelClass: 'image-dialog'
+    });
+
+    this.subs.add(
+      dialogRef.afterClosed().subscribe(
+        _ => this.store$.dispatch(new uiStore.SetIsBrowseDialogOpen(false))
+      )
+    );
+    // window.open(this.currentPinnedUrl(current_id));
   }
 
   public copyProductSourceScenes() {

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -153,12 +153,14 @@ export class ScenesListComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      this.scenesService.sarviewsEvents$().subscribe(
+      this.scenesService.sarviewsEvents$().pipe(
+        filter(events => !!events),
+      ).subscribe(
         events => {
           this.sarviewsEvents = events;
 
           const eventIds = events.map(event => event.event_id);
-          if (!eventIds.includes(this.selectedEvent) && eventIds.length > 0) {
+          if (!eventIds.includes(this.selectedEvent) && !!this.selectedEvent && eventIds.length > 0) {
             this.store$.dispatch(new scenesStore.SetSelectedSarviewsEvent(eventIds[0]));
           }
         }

--- a/src/app/components/shared/selectors/sarviews-event-magnitude-selector/sarviews-event-magnitude-selector.component.ts
+++ b/src/app/components/shared/selectors/sarviews-event-magnitude-selector/sarviews-event-magnitude-selector.component.ts
@@ -72,7 +72,10 @@ export class SarviewsEventMagnitudeSelectorComponent implements OnInit, OnDestro
         }),
       ).subscribe(
         magnitudeRange => {
-          this.magnitudeRange = magnitudeRange;
+          this.magnitudeRange = {
+            start: magnitudeRange?.start ?? 0,
+            end: magnitudeRange?.end ?? 10
+          };
           this.magnitudeValues$.next([magnitudeRange.start, magnitudeRange.end]);
         }
       )

--- a/src/app/components/shared/selectors/sarviews-event-magnitude-selector/sarviews-event-magnitude-selector.component.ts
+++ b/src/app/components/shared/selectors/sarviews-event-magnitude-selector/sarviews-event-magnitude-selector.component.ts
@@ -10,7 +10,7 @@ declare var wNumb: any;
 
 import noUiSlider from 'nouislider';
 import { Observable, Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, map, skip } from 'rxjs/operators';
 import { ScreenSizeService } from '@services';
 import { Breakpoints, SarviewsEventType } from '@models';
 
@@ -70,11 +70,12 @@ export class SarviewsEventMagnitudeSelectorComponent implements OnInit, OnDestro
         distinctUntilChanged((a, b) => {
           return a.start === b.start && a.end === b.end;
         }),
+        filter(range => !!range),
       ).subscribe(
         magnitudeRange => {
           this.magnitudeRange = {
-            start: magnitudeRange?.start ?? 0,
-            end: magnitudeRange?.end ?? 10
+            start: magnitudeRange?.start,
+            end: magnitudeRange?.end
           };
           this.magnitudeValues$.next([magnitudeRange.start, magnitudeRange.end]);
         }
@@ -95,11 +96,13 @@ export class SarviewsEventMagnitudeSelectorComponent implements OnInit, OnDestro
     const magnitudeValuesObserverable$ = temp.magnitudeValues$;
 
     this.subs.add(
-      magnitudeValuesObserverable$.subscribe(
+      magnitudeValuesObserverable$.pipe(
+        skip(1),
+      ).subscribe(
         ([start, end]) => {
           const action = new filterStore.SetSarviewsMagnitudeRange({
-            start: !!start ? start : 0,
-            end:  !!end ? end : 10
+            start: start,
+            end:  end
           });
           this.store$.dispatch(action);
         }

--- a/src/app/models/search.model.ts
+++ b/src/app/models/search.model.ts
@@ -90,4 +90,6 @@ export interface SarviewsFiltersType {
   magnitude: Range<null | number>;
   activeOnly: boolean;
   sarviewsEventNameFilter: string;
+  pinnedProductIDs: string[];
+  selectedEventID: string;
 }

--- a/src/app/services/browse-map.service.ts
+++ b/src/app/services/browse-map.service.ts
@@ -152,7 +152,7 @@ export class BrowseMapService {
     const pinned_ids = pinnedProductIds.filter(id => pinnedProductStates[id].isPinned);
 
     if (pinned_ids.length === 0) {
-      this.pinnedProducts.getLayers().clear();
+      this.pinnedProducts?.getLayers().clear();
     } else {
       this.unpinProducts(unpinned_ids);
       this.pinProducts(pinned_ids, pinnedProductStates);

--- a/src/app/services/map/map.service.ts
+++ b/src/app/services/map/map.service.ts
@@ -89,7 +89,7 @@ export class MapService {
   public mapInit$: EventEmitter<Map> = new EventEmitter();
 
   public getEventCoordinate(sarviews_id: string): Point {
-    return this.sarviewsFeaturesByID[sarviews_id].getGeometry() as Point;
+    return this.sarviewsFeaturesByID[sarviews_id]?.getGeometry() as Point ?? null;
   }
 
   public mousePosition$ = this.mousePositionSubject$.pipe(

--- a/src/app/services/sarviews-events.service.ts
+++ b/src/app/services/sarviews-events.service.ts
@@ -108,7 +108,7 @@ export class SarviewsEventsService {
   private getDates(event: SarviewsEvent | SarviewsProcessedEvent): Range<Date> {
     const eventDates = event.processing_timeframe;
 
-    if(!eventDates) {
+    if (!eventDates) {
       return event.processing_timeframe;
     }
     if (!!eventDates.start) {

--- a/src/app/services/sarviews-events.service.ts
+++ b/src/app/services/sarviews-events.service.ts
@@ -37,7 +37,7 @@ export class SarviewsEventsService {
         event => {
           return {
             ...event,
-            processing_timeframe: this.getDates(event),
+            processing_timeframe: !!event.processing_timeframe ? this.getDates(event) : null,
             point: this.getEventPoint(event.wkt),
           } as SarviewsEvent;
         }
@@ -58,7 +58,7 @@ export class SarviewsEventsService {
       map((event: SarviewsProcessedEvent) => {
         return {
           ...event,
-          processing_timeframe: this.getDates(event)
+          processing_timeframe: !!event.processing_timeframe ? this.getDates(event) : null
         };
       })
       );
@@ -107,6 +107,10 @@ export class SarviewsEventsService {
 
   private getDates(event: SarviewsEvent | SarviewsProcessedEvent): Range<Date> {
     const eventDates = event.processing_timeframe;
+
+    if(!eventDates) {
+      return event.processing_timeframe;
+    }
     if (!!eventDates.start) {
       eventDates.start = new Date(eventDates.start);
     }

--- a/src/app/services/saved-search.service.ts
+++ b/src/app/services/saved-search.service.ts
@@ -86,14 +86,18 @@ export class SavedSearchService {
     this.store$.select(filtersStore.getSarviewsEventNameFilter),
     this.store$.select(filtersStore.getSarviewsEventActiveFilter),
     this.store$.select(getSarviewsMagnitudeRange),
+    this.store$.select(scenesStore.getPinnedEventBrowseIDs),
+    this.store$.select(scenesStore.getSelectedSarviewsEvent).pipe(map(event => event?.event_id ?? '')),
   ).pipe(
     map(([dateRange, sarviewsEventTypes, sarviewsEventNameFilter,
-      activeOnly, magnitude]) => ({
+      activeOnly, magnitude, pinnedProductIDs, selectedEventID]) => ({
       dateRange,
       sarviewsEventTypes,
       sarviewsEventNameFilter,
       activeOnly,
-      magnitude
+      magnitude,
+      pinnedProductIDs,
+      selectedEventID
     })
   )
   );

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -95,7 +95,7 @@ export class SearchService {
       // this.store$.dispatch(new scene)
       this.store$.dispatch(new scenesStore.SetSelectedSarviewsEvent(filters.selectedEventID));
 
-        if(!!pinnedProductIds) {
+        if (!!pinnedProductIds) {
           this.store$.dispatch(new scenesStore.SetImageBrowseProducts(pinnedProductIds.reduce(
             (prev, curr) => {
               prev[curr] = {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -35,6 +35,7 @@ export class SearchService {
       new filterStore.ClearPerpendicularRange(),
       new filterStore.ClearTemporalRange(),
       new filterStore.ClearSeason(),
+      new filterStore.ClearSarviewsMagnitudeRange(),
       new uiStore.CloseFiltersMenu(),
     ];
 
@@ -91,6 +92,7 @@ export class SearchService {
       const filters = <models.SarviewsFiltersType>search.filters;
       const pinnedProductIds = filters.pinnedProductIDs;
       // if(!!filters.selectedEventID) {
+      // this.store$.dispatch(new scene)
       this.store$.dispatch(new scenesStore.SetSelectedSarviewsEvent(filters.selectedEventID));
 
         if(!!pinnedProductIds) {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -11,6 +11,7 @@ import * as uiStore from '@store/ui';
 import * as models from '@models';
 import { MapService, } from './map/map.service';
 import { WktService } from './wkt.service';
+import { PinnedProduct } from './browse-map.service';
 
 @Injectable({
   providedIn: 'root'
@@ -85,6 +86,26 @@ export class SearchService {
       if (filters.customPairIds) {
         this.store$.dispatch(new scenesStore.AddCustomPairs(filters.customPairIds));
       }
+    }
+    if (search.searchType === models.SearchType.SARVIEWS_EVENTS) {
+      const filters = <models.SarviewsFiltersType>search.filters;
+      const pinnedProductIds = filters.pinnedProductIDs;
+      // if(!!filters.selectedEventID) {
+      this.store$.dispatch(new scenesStore.SetSelectedSarviewsEvent(filters.selectedEventID));
+
+        if(!!pinnedProductIds) {
+          this.store$.dispatch(new scenesStore.SetImageBrowseProducts(pinnedProductIds.reduce(
+            (prev, curr) => {
+              prev[curr] = {
+                isPinned: true,
+                url: '',
+                wkt: ''
+              };
+              return prev;
+            }, {} as {[product_id in string]: PinnedProduct})
+          ));
+        }
+      // }
     }
 
     this.store$.dispatch(new filterStore.SetSavedSearch(search));

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -3,7 +3,7 @@ import { Router, ActivatedRoute, Params } from '@angular/router';
 
 import { Store, Action } from '@ngrx/store';
 import * as moment from 'moment';
-import { filter, map, skip, debounceTime, take } from 'rxjs/operators';
+import { filter, map, skip, debounceTime, take, distinctUntilChanged } from 'rxjs/operators';
 
 import { AppState } from '@store';
 import * as scenesStore from '@store/scenes';
@@ -200,7 +200,7 @@ export class UrlStateService {
     }, {
       name: 'pinnedProducts',
       source: this.store$.select(scenesStore.getPinnedEventBrowseIDs).pipe(
-        filter(ids => !!ids),
+        distinctUntilChanged(),
         map(ids => ({
           pinnedProducts: ids.join(',')
         }))

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -19,6 +19,7 @@ import { MapService } from './map/map.service';
 import { WktService } from './wkt.service';
 import { RangeService } from './range.service';
 import { PropertyService } from './property.service';
+import { PinnedProduct } from './browse-map.service';
 
 
 @Injectable({
@@ -196,8 +197,18 @@ export class UrlStateService {
         }))
       ),
       loader: this.loadEventID
+    }, {
+      name: 'PinnedProducts',
+      source: this.store$.select(scenesStore.getPinnedEventBrowseIDs).pipe(
+        filter(ids => !!ids),
+        map(ids => ({
+          pinnedProducts: ids.join(',')
+        }))
+      ),
+      loader: this.loadPinnedProducts
     }];
   }
+
 
   private missionParameters(): models.UrlParameter[] {
     return [{
@@ -637,6 +648,25 @@ export class UrlStateService {
   }
 
   private loadEventID = (event_id: string): Action => new scenesStore.SetSelectedSarviewsEvent(event_id);
+
+  private loadPinnedProducts = (pinnedProducts: string): Action => {
+    const productIDs = pinnedProducts.split(',');
+
+    const pinned = productIDs.reduce(
+      (prev, key) => {
+        let output = {} as PinnedProduct;
+        output.isPinned = true;
+        // const sarviewsProduct = this.sarviewsProducts.find(prod => prod.product_id === key)
+        output.url = '';
+        output.wkt = '';
+
+        prev[key] = output;
+        return prev;
+      }, {} as {[product_id in string]: PinnedProduct}
+    );
+
+      return new scenesStore.SetImageBrowseProducts(pinned);
+  }
 
   private loadIsDownloadQueueOpen = (isDownloadQueueOpen: string): Action => {
     return new uiStore.SetIsDownloadQueueOpen(!!isDownloadQueueOpen);

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -685,7 +685,7 @@ export class UrlStateService {
 
     const pinned = productIDs.reduce(
       (prev, key) => {
-        let output = {} as PinnedProduct;
+        const output = {} as PinnedProduct;
         output.isPinned = true;
         // const sarviewsProduct = this.sarviewsProducts.find(prod => prod.product_id === key)
         output.url = '';

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -721,7 +721,7 @@ export class UrlStateService {
   private loadEventTypes = (eventTypesStr: string): Action => {
     const eventTypes: models.SarviewsEventType[] = eventTypesStr
       .split(',')
-      .filter(direction => !Object.values(models.SarviewsEventType).includes(<models.SarviewsEventType>direction))
+      .filter(direction => !Object.values(models.SarviewsEventType).includes(models.SarviewsEventType[direction]))
       .map(direction => <models.SarviewsEventType>direction);
 
     return new filterStore.SetSarviewsEventTypes(eventTypes);

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -48,6 +48,7 @@ export class UrlStateService {
       ...this.missionParameters(),
       ...this.baselineParameters(),
       ...this.sbasParameters(),
+      ...this.eventMonitorParameters(),
     ];
 
     this.urlParamNames = params.map(param => param.name);
@@ -182,6 +183,19 @@ export class UrlStateService {
         }))
       ),
       loader: this.loadSbasPairs
+    }];
+  }
+
+  private eventMonitorParameters(): models.UrlParameter[] {
+    return [{
+      name: 'eventID',
+      source: this.store$.select(scenesStore.getSelectedSarviewsEvent).pipe(
+        filter(event => !!event),
+        map(event => ({
+          eventID: event.event_id
+        }))
+      ),
+      loader: this.loadEventID
     }];
   }
 
@@ -621,6 +635,8 @@ export class UrlStateService {
 
     return new scenesStore.AddCustomPairs(pairs);
   }
+
+  private loadEventID = (event_id: string): Action => new scenesStore.SetSelectedSarviewsEvent(event_id);
 
   private loadIsDownloadQueueOpen = (isDownloadQueueOpen: string): Action => {
     return new uiStore.SetIsDownloadQueueOpen(!!isDownloadQueueOpen);

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -20,6 +20,8 @@ import { WktService } from './wkt.service';
 import { RangeService } from './range.service';
 import { PropertyService } from './property.service';
 import { PinnedProduct } from './browse-map.service';
+// import { MatDialog } from '@angular/material/dialog';
+// import { ImageDialogComponent } from '@components/results-menu/scene-detail/image-dialog';
 
 
 @Injectable({
@@ -39,17 +41,18 @@ export class UrlStateService {
     private wktService: WktService,
     private rangeService: RangeService,
     private router: Router,
+    // private dialog: MatDialog,
     private prop: PropertyService,
   ) {
     const params = [
       ...this.datasetParam(),
+      ...this.eventMonitorParameters(),
       ...this.mapParameters(),
       ...this.uiParameters(),
       ...this.filtersParameters(),
       ...this.missionParameters(),
       ...this.baselineParameters(),
       ...this.sbasParameters(),
-      ...this.eventMonitorParameters(),
     ];
 
     this.urlParamNames = params.map(param => param.name);
@@ -257,7 +260,15 @@ export class UrlStateService {
         map(isOnDemandOpen => ({ isOnDemandOpen }))
       ),
       loader: this.loadIsOnDemandQueueOpen
-    }];
+    },
+    // {
+    //   name: 'isImgBrowseOpen',
+    //   source: this.store$.select(uiStore.getIsBrowseDialogOpen).pipe(
+    //     map( isImgBrowseOpen => ({isImgBrowseOpen}))
+    //   ),
+    //   loader: this.loadIsImageBrowseOpen
+    // }
+  ];
   }
 
   private filtersParameters(): models.UrlParameter[] {
@@ -675,6 +686,23 @@ export class UrlStateService {
   private loadIsOnDemandQueueOpen = (isOnDemandQueueOpen: string): Action => {
     return new uiStore.SetIsOnDemandQueueOpen(!!isOnDemandQueueOpen);
   }
+
+  // private loadIsImageBrowseOpen = (isImageBrowseOpen: string): Action => {
+  //   this.dialog.open(ImageDialogComponent, {
+  //     width: '99%',
+  //     maxWidth: '99%',
+  //     height: '99%',
+  //     maxHeight: '99%',
+  //     panelClass: 'image-dialog'
+  //   });
+
+  //   // this.subs.add(
+  //   //   dialogRef.afterClosed().subscribe(
+  //   //     _ => this.store$.dispatch(new uiStore.SetIsBrowseDialogOpen(false))
+  //   //   )
+  //   // );
+  //   return new uiStore.SetIsBrowseDialogOpen(!!isImageBrowseOpen);
+  // }
 
   private updateShouldSearch(): void {
     this.store$.select(scenesStore.getAreResultsLoaded).pipe(

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -382,6 +382,19 @@ export class UrlStateService {
         map(magnitudeRange => ({magnitude: magnitudeRange}))
       ),
       loader: this.loadMagnitudeRange
+    }, {
+      name: 'activeEvents',
+      source: this.store$.select(filterStore.getSarviewsEventActiveFilter).pipe(
+        map(activeEvents => ({activeEvents}))
+      ),
+      loader: this.loadOnlyActiveEvents
+    }, {
+      name: 'eventTypes',
+      source: this.store$.select(filterStore.getSarviewsEventTypes).pipe(
+        map(types => types.join(',')),
+        map(eventTypes => ({eventTypes}))
+      ),
+      loader: this.loadEventTypes
     }];
   }
 
@@ -704,6 +717,17 @@ export class UrlStateService {
     end: range[1]
   });
   }
+
+  private loadEventTypes = (eventTypesStr: string): Action => {
+    const eventTypes: models.SarviewsEventType[] = eventTypesStr
+      .split(',')
+      .filter(direction => !Object.values(models.SarviewsEventType).includes(<models.SarviewsEventType>direction))
+      .map(direction => <models.SarviewsEventType>direction);
+
+    return new filterStore.SetSarviewsEventTypes(eventTypes);
+  }
+
+  private loadOnlyActiveEvents = (activeOnly: boolean): Action => new filterStore.SetSarviewsEventActiveFilter(activeOnly);
 
   // private loadIsImageBrowseOpen = (isImageBrowseOpen: string): Action => {
   //   this.dialog.open(ImageDialogComponent, {

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -46,13 +46,13 @@ export class UrlStateService {
   ) {
     const params = [
       ...this.datasetParam(),
-      ...this.eventMonitorParameters(),
       ...this.mapParameters(),
       ...this.uiParameters(),
       ...this.filtersParameters(),
       ...this.missionParameters(),
       ...this.baselineParameters(),
       ...this.sbasParameters(),
+      ...this.eventMonitorParameters(),
     ];
 
     this.urlParamNames = params.map(param => param.name);
@@ -194,9 +194,9 @@ export class UrlStateService {
     return [{
       name: 'eventID',
       source: this.store$.select(scenesStore.getSelectedSarviewsEvent).pipe(
-        filter(event => !!event),
+        // filter(event => !!event),
         map(event => ({
-          eventID: event.event_id
+          eventID: event?.event_id ?? ''
         }))
       ),
       loader: this.loadEventID

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -198,7 +198,7 @@ export class UrlStateService {
       ),
       loader: this.loadEventID
     }, {
-      name: 'PinnedProducts',
+      name: 'pinnedProducts',
       source: this.store$.select(scenesStore.getPinnedEventBrowseIDs).pipe(
         filter(ids => !!ids),
         map(ids => ({

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -375,6 +375,13 @@ export class UrlStateService {
         map(flightDirs => ({ flightDirs }))
       ),
       loader: this.loadFlightDirections
+    }, {
+      name: 'magnitude',
+      source: this.store$.select(filterStore.getSarviewsMagnitudeRange).pipe(
+        map(range => this.rangeService.toStringWithNegatives(range)),
+        map(magnitudeRange => ({magnitude: magnitudeRange}))
+      ),
+      loader: this.loadMagnitudeRange
     }];
   }
 
@@ -685,6 +692,17 @@ export class UrlStateService {
 
   private loadIsOnDemandQueueOpen = (isOnDemandQueueOpen: string): Action => {
     return new uiStore.SetIsOnDemandQueueOpen(!!isOnDemandQueueOpen);
+  }
+
+  private loadMagnitudeRange = (rangeStr: string): Action => {
+    const range = rangeStr
+    .split('to')
+    .map(v => +v);
+
+  return new filterStore.SetSarviewsMagnitudeRange({
+    start: range[0],
+    end: range[1]
+  });
   }
 
   // private loadIsImageBrowseOpen = (isImageBrowseOpen: string): Action => {

--- a/src/app/store/scenes/scenes.effect.ts
+++ b/src/app/store/scenes/scenes.effect.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { of } from 'rxjs';
-import { map, switchMap, catchError, distinctUntilChanged } from 'rxjs/operators';
+import { map, switchMap, catchError, distinctUntilChanged, debounceTime, filter } from 'rxjs/operators';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { UnzipApiService } from '@services/unzip-api.service';
 import { NotificationService } from '@services/notification.service';
@@ -52,6 +52,8 @@ export class ScenesEffects {
     ofType<SetSelectedSarviewsEvent>(ScenesActionType.SET_SELECTED_SARVIEWS_EVENT),
     distinctUntilChanged(),
     switchMap(action => this.sarviewsService.getEventFeature(action.payload)),
+    debounceTime(500),
+    filter(event => !!event.products),
     map(processedEvent => new SetSarviewsEventProducts(!!processedEvent.products ? processedEvent.products : []))
   ));
   private showUnzipApiLoadError(product: CMRProduct): void {

--- a/src/app/store/scenes/scenes.effect.ts
+++ b/src/app/store/scenes/scenes.effect.ts
@@ -52,7 +52,7 @@ export class ScenesEffects {
     ofType<SetSelectedSarviewsEvent>(ScenesActionType.SET_SELECTED_SARVIEWS_EVENT),
     distinctUntilChanged(),
     switchMap(action => this.sarviewsService.getEventFeature(action.payload)),
-    map(processedEvent => new SetSarviewsEventProducts(processedEvent.products))
+    map(processedEvent => new SetSarviewsEventProducts(!!processedEvent.products ? processedEvent.products : []))
   ));
   private showUnzipApiLoadError(product: CMRProduct): void {
     this.notificationService.error(

--- a/src/app/store/scenes/scenes.effect.ts
+++ b/src/app/store/scenes/scenes.effect.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { of } from 'rxjs';
-import { map, switchMap, catchError, distinctUntilChanged, debounceTime, filter } from 'rxjs/operators';
+import { map, switchMap, catchError, distinctUntilChanged, filter } from 'rxjs/operators';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { UnzipApiService } from '@services/unzip-api.service';
 import { NotificationService } from '@services/notification.service';
@@ -52,7 +52,7 @@ export class ScenesEffects {
     ofType<SetSelectedSarviewsEvent>(ScenesActionType.SET_SELECTED_SARVIEWS_EVENT),
     distinctUntilChanged(),
     switchMap(action => this.sarviewsService.getEventFeature(action.payload)),
-    debounceTime(500),
+    // debounceTime(500),
     filter(event => !!event.products),
     map(processedEvent => new SetSarviewsEventProducts(!!processedEvent.products ? processedEvent.products : []))
   ));

--- a/src/app/store/scenes/scenes.reducer.ts
+++ b/src/app/store/scenes/scenes.reducer.ts
@@ -677,6 +677,13 @@ export const getImageBrowseProducts = createSelector(
   }
 );
 
+export const getPinnedEventBrowseIDs = createSelector(
+  getScenesState,
+  state => {
+    return Object.keys(state.pinnedProductBrowses).filter(product_id => state.pinnedProductBrowses[product_id].isPinned)
+  }
+)
+
 function eqSet(aSet, bSet): boolean {
   if (aSet.size !== bSet.size) {
     return false;

--- a/src/app/store/scenes/scenes.reducer.ts
+++ b/src/app/store/scenes/scenes.reducer.ts
@@ -680,9 +680,9 @@ export const getImageBrowseProducts = createSelector(
 export const getPinnedEventBrowseIDs = createSelector(
   getScenesState,
   state => {
-    return Object.keys(state.pinnedProductBrowses).filter(product_id => state.pinnedProductBrowses[product_id].isPinned)
+    return Object.keys(state.pinnedProductBrowses).filter(product_id => state.pinnedProductBrowses[product_id].isPinned);
   }
-)
+);
 
 function eqSet(aSet, bSet): boolean {
   if (aSet.size !== bSet.size) {


### PR DESCRIPTION
For DS-3925

Switching Search Types no longer clears filters, the selected event, and selected products on a non-empty Event Monitoring search.

Users can now share event monitoring searches with:
- The currently selected event and the user selected products
- The current event monitor search filters

Additionally, selecting items in the current event's products list will have those items pinned on the map when opening the image viewer dialog window. 

The "Open selected products in SARVIEWS" button in the products list view is now "Open selected products on map" and opens the image viewer dialog with the selected items pinned to it.

The "Open product in SARVIEWS" button on the image dialog map is now "Open pinned products in SARVIEWS", and functions as written.