### PR TITLE
Event Search Clear Autocomplete Fix

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -449,6 +449,10 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     this.store$.dispatch(new uiStore.CloseResultsMenu());
 
     this.searchService.clear(this.searchType);
+
+    if(this.searchType === SearchType.SARVIEWS_EVENTS) {
+      this.store$.dispatch(new searchStore.MakeSearch());
+    }
   }
 
   private updateMaxSearchResults(): void {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -450,7 +450,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
     this.searchService.clear(this.searchType);
 
-    if(this.searchType === SearchType.SARVIEWS_EVENTS) {
+    if (this.searchType === SearchType.SARVIEWS_EVENTS) {
       this.store$.dispatch(new searchStore.MakeSearch());
     }
   }


### PR DESCRIPTION
- Event name filter autocomplete works after clearing search
- Results menu is reopened with default event search when clearing event search