### PR TITLE
Better Cleared Event Search Autocomplete Fix

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -449,10 +449,6 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
     this.store$.dispatch(new uiStore.CloseResultsMenu());
 
     this.searchService.clear(this.searchType);
-
-    if (this.searchType === SearchType.SARVIEWS_EVENTS) {
-      this.store$.dispatch(new searchStore.MakeSearch());
-    }
   }
 
   private updateMaxSearchResults(): void {

--- a/src/app/components/shared/selectors/sarviews-event-search-selector/sarviews-event-search-selector.component.ts
+++ b/src/app/components/shared/selectors/sarviews-event-search-selector/sarviews-event-search-selector.component.ts
@@ -2,10 +2,13 @@ import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { Store } from '@ngrx/store';
-import { ScenesService } from '@services';
+import { SarviewsEventsService, ScenesService } from '@services';
 import { AppState } from '@store';
 
 import * as filterStore from '@store/filters';
+import { getIsResultsMenuOpen } from '@store/ui';
+import { combineLatest } from 'rxjs';
+import { map, withLatestFrom } from 'rxjs/operators';
 import { SubSink } from 'subsink';
 @Component({
   selector: 'app-sarviews-event-search-selector',
@@ -15,14 +18,22 @@ import { SubSink } from 'subsink';
 export class SarviewsEventSearchSelectorComponent implements OnInit, OnDestroy {
   @ViewChild('eventsQueryForm') public eventsQueryForm: NgForm;
 
-  public filteredEvents$ = this.sceneService.sarviewsEvents$();
+  public filteredEvents$ = combineLatest([
+    this.sceneService.sarviewsEvents$(),
+    this.sceneService.filterSarviewsEventsByName$(this.eventService.getSarviewsEvents$())
+  ]).pipe(
+    map(([filteredEvents, allEvents]) => ({filteredEvents, allEvents})),
+    withLatestFrom(this.store$.select(getIsResultsMenuOpen)),
+    map(([events, resultsOpen]) => resultsOpen ? events.filteredEvents : events.allEvents)
+  );
 
   public eventQuery = '';
 
   private subs = new SubSink();
 
   constructor(private store$: Store<AppState>,
-              private sceneService: ScenesService) { }
+              private sceneService: ScenesService,
+              private eventService: SarviewsEventsService) { }
 
   ngOnInit(): void {
     this.subs.add(


### PR DESCRIPTION
results menu no longer opens after clearing search on event search like other search types, and autocomplete works without existing event search.