### PR TITLE
Removes Browse Map on Non-Event Search Type Results

### DIFF
--- a/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/browse-list/browse-list.component.html
@@ -12,8 +12,8 @@
       <img [src]="scene.browses[0]"
        onerror="this.src='assets/no-browse.png'"
        class="browse-image no-drag">
-       <mat-checkbox [checked]="productBrowseStates[scene.id]?.isPinned" (change)="onPinProduct(scene.id);" (click)="$event.stopPropagation()">
-      </mat-checkbox>
+       <!-- <mat-checkbox [checked]="productBrowseStates[scene.id]?.isPinned" (change)="onPinProduct(scene.id);" (click)="$event.stopPropagation()">
+      </mat-checkbox> -->
       <div class="browse-image--date">{{ scene.metadata.date | shortDate }}</div>
     </div>
   </div>

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -42,7 +42,7 @@
     </div>
 
     <div fxFlex id="browse-map" fxFlex class="browse-map--size" fxLayout="row-reverse" fxLayoutAlign="end end" >
-      <div fxFlex fxLayout="column" fxLayoutAlign="start" class="ol-control ol-unselectable" style="background-color: rgba(0, 0, 0, 0) !important; z-index: 1;">
+      <div *ngIf="(searchType$ | async) === searchTypes.SARVIEWS_EVENTS" fxFlex fxLayout="column" fxLayoutAlign="start" class="ol-control ol-unselectable" style="background-color: rgba(0, 0, 0, 0) !important; z-index: 1;">
         <div style="padding: 2px; border-radius: 4px; height: 100%; margin-bottom: 15px; margin-left: 15px; background-color: rgba(255, 255, 255, 0.4);">
           <div (click)="onPinProduct(currentSarviewsProduct?.product_id ?? scene?.id)" style="height: 32px; padding-top: 10px; background-color: rgba(0, 60, 136, 0.5);">
             <mat-icon style="margin-left: 11px;">push_pin</mat-icon>

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.ts
@@ -238,9 +238,13 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
 
       self.isImageLoading = false;
 
-      const wkt = scene.metadata.polygon;
-
-      browseService.setBrowse(browse, wkt);
+      // const wkt = scene.metadata.polygon;
+      const [width, height] = [
+        this.naturalWidth, this.naturalHeight
+      ];
+      browseService.setBrowse(browse, {width,
+        height
+      });
     });
 
     this.image.src = browse;
@@ -261,7 +265,7 @@ export class ImageDialogComponent implements OnInit, AfterViewInit, OnDestroy {
 
       self.isImageLoading = false;
 
-      browseService.setBrowse(product.files.browse_url, product.granules[0].wkt );
+      browseService.setMapBrowse(product.files.browse_url, product.granules[0].wkt );
     });
 
     this.image.src = product.files.browse_url;

--- a/src/app/services/browse-map.service.ts
+++ b/src/app/services/browse-map.service.ts
@@ -10,15 +10,16 @@ import { mapOptions } from '@models';
 import TileLayer from 'ol/layer/Tile';
 import { Layer, Vector } from 'ol/layer';
 import Polygon from 'ol/geom/Polygon';
-import { getCenter } from 'ol/extent';
+import { Extent, getCenter } from 'ol/extent';
 import VectorSource from 'ol/source/Vector';
 import WKT from 'ol/format/WKT';
 import LayerGroup from 'ol/layer/Group';
 import { Collection } from 'ol';
-// interface Dimension {
-//   width: number;
-//   height: number;
-// }
+import Projection from 'ol/proj/Projection';
+interface Dimension {
+  width: number;
+  height: number;
+}
 
 export interface PinnedProduct {
   isPinned: boolean;
@@ -41,7 +42,7 @@ export class BrowseMapService {
   //   // layers: l => !!this.pinnedProducts.getLayersArray().find(pinned => pinned.get("product_id") === l?.get("product_id")),
   // });
 
-  public setBrowse(browse: string, wkt: string = ''): void {
+  public setMapBrowse(browse: string, wkt: string = ''): void {
     const format = new WKT();
     const feature = format.readFeature(wkt, {dataProjection: 'EPSG:4326',
     featureProjection: 'EPSG:3857'});
@@ -191,8 +192,12 @@ export class BrowseMapService {
   private update(view: View, layers: Layer[]): void {
     this.map.setView(view);
     const mapLayers = this.map.getLayers();
-    const baseLayers = layers.slice(0, 3);
-    baseLayers.forEach((l, idx) => mapLayers.setAt(idx + 1, l));
+    if(layers.length > 1) {
+      const baseLayers = layers.slice(0, 3);
+      baseLayers.forEach((l, idx) => mapLayers.setAt(idx + 1, l));
+    } else {
+      mapLayers.setAt(0, layers[0]);
+    }
   }
 
   private newMap(view: View, layers: Layer[]): Map {
@@ -206,4 +211,51 @@ export class BrowseMapService {
   cleanup(): void {
     this.map = null;
   }
+
+
+  public setBrowse(browse: string, dim: Dimension): void {
+    const extent = [0, 0, dim.width, dim.height] as Extent;
+
+    const projection = new Projection({
+      code: 'scene-browse',
+      units: 'pixels',
+      extent
+    });
+
+    const layer = new ImageLayer({
+      source: new Static({
+        url: browse,
+        projection: projection,
+        imageExtent: extent,
+      })
+    });
+
+    const view = new View({
+      projection: projection,
+      center: getCenter(extent),
+      zoom: 1,
+      minZoom: 1,
+      maxZoom: 4,
+    });
+
+    if (this.map) {
+      this.update(view, [layer]);
+    } else {
+      this.map = this.newMap(view, [layer]);
+    }
+  }
+
+  // private update(view: View, layer: ImageLayer): void {
+  //   this.map.setView(view);
+  //   const mapLayers = this.map.getLayers();
+  //   mapLayers.setAt(0, layer);
+  // }
+
+  // private newMap(view: View, layer: ImageLayer): Map {
+  //   return new Map({
+  //     layers: [ layer ],
+  //     target: 'browse-map',
+  //     view
+  //   });
+  // }
 }

--- a/src/app/services/browse-map.service.ts
+++ b/src/app/services/browse-map.service.ts
@@ -192,7 +192,7 @@ export class BrowseMapService {
   private update(view: View, layers: Layer[]): void {
     this.map.setView(view);
     const mapLayers = this.map.getLayers();
-    if(layers.length > 1) {
+    if (layers.length > 1) {
       const baseLayers = layers.slice(0, 3);
       baseLayers.forEach((l, idx) => mapLayers.setAt(idx + 1, l));
     } else {


### PR DESCRIPTION
Non-Event Search Type scene and product browses are now opened in image viewer without map and additional map controls.