### PR TITLE
Events List Active Icon Fix (DS-3926)

### DIFF
--- a/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.html
+++ b/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.html
@@ -7,21 +7,8 @@
     [class.selected]="selected"
     [ngClass]="{'mobile-size': breakpoint <= breakpoints.SMALL}">
 
-<div class="image-flex" *ngIf="breakpoint > breakpoints.SMALL">
-  <!-- <img class="list-thumbnail"
-  [src]=""
-  onerror="this.src='assets/no-thumb.png'"
-  matBadgeOverlap="false"
-  matListAvatar> -->
+  <img [src]="getEventIcon()" class="event-list-thumbnail">
 
-</div>
-<mat-icon
-class="event-list-thumbnail"
-[svgIcon]="event.event_type === 'quake' ?
-'Earthquake' + (isActive() ? '' : '_inactive')
-: 'Volcano' + (isActive() ? '' : '_inactive')"
->
-</mat-icon>
   <div class="div-flex">
     <div class="div-flex-column">
       <div class="div-flex"

--- a/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.ts
+++ b/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.ts
@@ -7,6 +7,7 @@ import * as sceneStore from '@store/scenes';
 import { MapService } from '@services';
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
+import * as moment from 'moment';
 
 @Component({
   selector: 'app-sarviews-event',
@@ -50,13 +51,22 @@ export class SarviewsEventComponent implements OnInit {
   }
 
   public isActive(): boolean {
-    const currentDate = new Date();
+    const currentDate = moment(new Date()).startOf('day').toDate();
 
     if (!!this.event.processing_timeframe.end) {
-      return currentDate <= new Date(this.event.processing_timeframe.end);
+      return currentDate <= moment(this.event.processing_timeframe.end).endOf('day').toDate();
     }
 
     return true;
+  }
+
+  public getEventIcon(): string {
+    let eventIconName = this.event.event_type === 'quake' ? 'Earthquake' : 'Volcano';
+    if(!this.isActive()) {
+      eventIconName += '_inactive';
+    }
+
+    return '/assets/icons/' + eventIconName + '.svg';
   }
 
   public eventIcon(): string {

--- a/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.ts
+++ b/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.ts
@@ -65,7 +65,7 @@ export class SarviewsEventComponent implements OnInit {
 
   public getEventIcon(): string {
     let eventIconName = this.event.event_type === 'quake' ? 'Earthquake' : 'Volcano';
-    if(!this.isActive()) {
+    if (!this.isActive()) {
       eventIconName += '_inactive';
     }
 


### PR DESCRIPTION
Active and inactive volcanic events now use the right colors in the default results list.

For some reason mat-icon would render the volcano icons with the inactive quake event icon colors. I couldn't find any explanation for this online (I might be an undocumented bug, because the correct behavior appears depending on user filters, and the colors are embedded in the svg files themselves with no programmatic coloring), but the workaround was to use an img tag rather than an svg mat-icon.