### PR TITLE
Browse Overlay Dataset Bug Fixes (DS-4017)

### DIFF
--- a/src/app/components/map/map-controls/map-controls.component.html
+++ b/src/app/components/map/map-controls/map-controls.component.html
@@ -99,11 +99,17 @@
         </mat-button-toggle>
         <mat-button-toggle class="control-mat-button-toggle"
         *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"
+        [disabled]="!(isBrowseOverlayEnabled$ | async) || (selectedScene$ | async).browses.length < 2"
+        matTooltipDisabled="!(isBrowseOverlayEnabled$ | async) ? 'Browse Overlays for current scene dataset not available' :
+        'Current Scene only has one available browse'"
         (click)="onDecrementBrowseIndex()"
         matTooltip="Change selected scene browse">
         <mat-icon class="control-icon">arrow_back</mat-icon>
         </mat-button-toggle>
           <mat-button-toggle class="control-mat-button-toggle"
+          [disabled]="!(isBrowseOverlayEnabled$ | async)  || (selectedScene$ | async).browses.length < 2"
+          matTooltipDisabled="!(isBrowseOverlayEnabled$ | async) ? 'Browse Overlays for current scene dataset not available' :
+            'Current Scene only has one available browse'"
           *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"
           (click)="onIncrementBrowseIndex()"
           matTooltip="Change selected scene browse">
@@ -121,7 +127,11 @@
       <label>Browse Opacity</label>
       </div>
       <div fxLayout="row">
-      <mat-slider class="opacity-slider" name="layerType" step="0.05" value="1" min="0.0" max="1.0" (input)="onSetOpacity($event)" >
+      <mat-slider
+      [disabled]="!(isBrowseOverlayEnabled$ | async)"
+      [matTooltip]="(isBrowseOverlayEnabled$ | async) ? 'Adjust Overlay Opacity' :
+      'Product Overlays for current scene dataset not available'"
+      class="opacity-slider" name="layerType" step="0.05" value="1" min="0.0" max="1.0" (input)="onSetOpacity($event)" >
       </mat-slider>
       </div>
     </div>

--- a/src/app/components/map/map-controls/map-controls.component.ts
+++ b/src/app/components/map/map-controls/map-controls.component.ts
@@ -43,7 +43,7 @@ export class MapControlsComponent implements OnInit, OnDestroy {
       this.store$.select(sceneStore.getSelectedSarviewsEventProducts).pipe(startWith([]))]
     ).pipe(
       map(([searchtype, selectedScene, datasetID, selectedEventProducts]) => {
-        switch(searchtype) {
+        switch (searchtype) {
           case models.SearchType.DATASET:
             return datasetID === 'AVNIR'
             || datasetID === 'SENTINEL-1'
@@ -64,7 +64,7 @@ export class MapControlsComponent implements OnInit, OnDestroy {
 
         }
       })
-    )
+    );
 
   public currentBrowseID = '';
 

--- a/src/app/components/map/map-controls/map-controls.component.ts
+++ b/src/app/components/map/map-controls/map-controls.component.ts
@@ -13,9 +13,10 @@ import * as services from '@services';
 import { LonLat, SarviewsProduct, SearchType } from '@models';
 import { combineLatest } from 'rxjs';
 
-import { filter, startWith, tap } from 'rxjs/operators';
+import { filter, map, startWith, tap } from 'rxjs/operators';
 import { ToggleBrowseOverlay } from '@store/map';
 import { MatSliderChange } from '@angular/material/slider';
+import { getSelectedDatasetId } from '@store/filters';
 
 @Component({
   selector: 'app-map-controls',
@@ -34,6 +35,36 @@ export class MapControlsComponent implements OnInit, OnDestroy {
     tap(_ => this.browseIndex = 0),
     filter(event => !!event),
   startWith(null));
+
+  public isBrowseOverlayEnabled$ = combineLatest([
+    this.store$.select(searchStore.getSearchType),
+    this.store$.select(sceneStore.getSelectedScene).pipe(filter(scene => !!scene)),
+    this.store$.select(getSelectedDatasetId),
+      this.store$.select(sceneStore.getSelectedSarviewsEventProducts).pipe(startWith([]))]
+    ).pipe(
+      map(([searchtype, selectedScene, datasetID, selectedEventProducts]) => {
+        switch(searchtype) {
+          case models.SearchType.DATASET:
+            return datasetID === 'AVNIR'
+            || datasetID === 'SENTINEL-1'
+            || datasetID === 'SENTINEL-1 INTERFEROGRAM (BETA)'
+            || datasetID === 'UAVSAR';
+          case models.SearchType.SARVIEWS_EVENTS:
+            return selectedEventProducts?.length > 0;
+          case models.SearchType.LIST:
+            return selectedScene.dataset === 'ALOS'
+            || selectedScene.dataset === 'Sentinel-1A'
+            || selectedScene.dataset === 'Sentinel-1B'
+            || selectedScene.dataset === 'Sentinel-1 Interferogram (BETA)'
+            || selectedScene.dataset === 'UAVSAR';
+          case models.SearchType.CUSTOM_PRODUCTS:
+            return true;
+          default:
+            return false;
+
+        }
+      })
+    )
 
   public currentBrowseID = '';
 

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -407,7 +407,7 @@ export class MapComponent implements OnInit, OnDestroy  {
 
   private scenePolygonsLayer$(projection: string): Observable<VectorLayer> {
     return this.scenesService.scenes$().pipe(
-      map(scenes => scenes.filter(scene => scene.id !== this.selectedScene.id)),
+      map(scenes => scenes.filter(scene => scene.id !== this.selectedScene?.id)),
       map(scenes => this.scenesToFeature(scenes, projection)),
       map(features => this.featuresToSource(features, polygonStyle.scene)),
       tap(layer => layer.set('selectable', 'true')),

--- a/src/app/store/map/map.effect.ts
+++ b/src/app/store/map/map.effect.ts
@@ -51,7 +51,7 @@ export class MapEffects {
     // map(([selected_scene, _]) => selected_scene),
     withLatestFrom(this.store$.select(getSelectedDataset)),
     filter(([[_, searchType], dataset]) => {
-    if(searchType === SearchType.DATASET) {
+    if (searchType === SearchType.DATASET) {
       return dataset?.id === 'AVNIR'
       || dataset?.id === 'SENTINEL-1'
       || dataset?.id === 'SENTINEL-1 INTERFEROGRAM (BETA)'
@@ -67,7 +67,7 @@ export class MapEffects {
     map(([selected, products]) => products[selected]),
     withLatestFrom(this.store$.select(getSearchType)),
     filter(([product, searchType]) => {
-      if(searchType === SearchType.LIST) {
+      if (searchType === SearchType.LIST) {
         return product.dataset === 'ALOS'
         || product.dataset === 'Sentinel-1A'
         || product.dataset === 'Sentinel-1B'

--- a/src/app/store/map/map.effect.ts
+++ b/src/app/store/map/map.effect.ts
@@ -45,22 +45,40 @@ export class MapEffects {
 
   public onSetSelectedScene = createEffect(() => this.actions$.pipe(
     ofType<SetSelectedScene>(ScenesActionType.SET_SELECTED_SCENE),
+    map(action => action.payload),
     withLatestFrom(this.store$.select(getSearchType)),
     filter(([_, searchtype]) => searchtype !== models.SearchType.SARVIEWS_EVENTS),
-    map(([selected_scene, _]) => selected_scene),
+    // map(([selected_scene, _]) => selected_scene),
     withLatestFrom(this.store$.select(getSelectedDataset)),
-    filter(([_, dataset]) =>
-      dataset.id === 'AVNIR'
-      || dataset.id === 'SENTINEL-1'
-      || dataset.id === 'SENTINEL-1 INTERFEROGRAM (BETA)'
-      || dataset.id === 'UAVSAR'),
-    map(([action, _]) => action.payload),
-    filter(scene => !!scene),
+    filter(([[_, searchType], dataset]) => {
+    if(searchType === SearchType.DATASET) {
+      return dataset?.id === 'AVNIR'
+      || dataset?.id === 'SENTINEL-1'
+      || dataset?.id === 'SENTINEL-1 INTERFEROGRAM (BETA)'
+      || dataset?.id === 'UAVSAR';
+    }
+    return searchType !== SearchType.BASELINE && searchType !== SearchType.SBAS;
+  }),
+    map(([[selectedSceneID, _], __]) => selectedSceneID),
+    filter(sceneID => !!sceneID),
     withLatestFrom(this.store$.select(getProducts)),
     filter(([selected, products]) => !!selected && !!products),
     filter(([selected, products]) => products[selected].browses.length > 0),
-    tap(([selected, products]) => {
-      const selectedProduct = products[selected];
+    map(([selected, products]) => products[selected]),
+    withLatestFrom(this.store$.select(getSearchType)),
+    filter(([product, searchType]) => {
+      if(searchType === SearchType.LIST) {
+        return product.dataset === 'ALOS'
+        || product.dataset === 'Sentinel-1A'
+        || product.dataset === 'Sentinel-1B'
+        || product.dataset === 'Sentinel-1 Interferogram (BETA)'
+        || product.dataset === 'UAVSAR';
+      }
+      return true;
+    }),
+    map(([product, _]) => product),
+    filter(product => product.browses.length > 0),
+    tap((selectedProduct) => {
       if (selectedProduct.browses[0] !== '/assets/no-browse.png') {
         this.mapService.setSelectedBrowse(selectedProduct.browses[0], selectedProduct.metadata.polygon);
       }


### PR DESCRIPTION
Fixes for comments on DS-4017, problems number 1-3, 6.
- Browse overlay controls grayed out when selected scene is not of right type
- Browse overlay arrows now grayed out when only 1 product browse available
- List search now checks if product is part of valid dataset to overlay on map
 - Overlay boxes are removed from map again when switching search types