### PR TITLE
Remove SBAS Pairs with Same Absolute Orbit

### DIFF
--- a/src/app/services/pair.service.ts
+++ b/src/app/services/pair.service.ts
@@ -110,7 +110,6 @@ export class PairService {
         const P2StartDate = new Date(scene.metadata.date.toISOString());
         const P2StopDate = new Date(scene.metadata.stopDate.toISOString());
 
-
         if (orbitalDifference === 0) {
           return;
         }

--- a/src/app/services/pair.service.ts
+++ b/src/app/services/pair.service.ts
@@ -111,7 +111,7 @@ export class PairService {
         const P2StopDate = new Date(scene.metadata.stopDate.toISOString());
 
 
-        if(orbitalDifference === 0) {
+        if (orbitalDifference === 0) {
           return;
         }
 

--- a/src/app/services/pair.service.ts
+++ b/src/app/services/pair.service.ts
@@ -103,10 +103,17 @@ export class PairService {
         const tempDiff = scene.metadata.temporal - root.metadata.temporal;
         const perpDiff = Math.abs(scene.metadata.perpendicular - root.metadata.perpendicular);
 
+        const orbitalDifference = scene.metadata.absoluteOrbit[0] - root.metadata.absoluteOrbit[0];
+
         const P1StartDate = new Date(root.metadata.date.toISOString());
         const P1StopDate = new Date(root.metadata.stopDate.toISOString());
         const P2StartDate = new Date(scene.metadata.date.toISOString());
         const P2StopDate = new Date(scene.metadata.stopDate.toISOString());
+
+
+        if(orbitalDifference === 0) {
+          return;
+        }
 
         if (!!season.start && !!season.end) {
             if (!this.dayInSeason(P1StartDate, P1StopDate, P2StartDate, P2StopDate, season)) {

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -65,7 +65,7 @@ export class ProductService {
 
       path: +g.p,
       frame:  +g.f,
-      absoluteOrbit: Array.isArray(g.o) ? g.o : [g.o],
+      absoluteOrbit: Array.isArray(g.o) ? g.o.map(val => +val) : [+g.o],
 
       faradayRotation: +g.fr,
       offNadirAngle: +g.on,


### PR DESCRIPTION
- SBAS no longer makes pairs with reference and secondary scene share the same absolute orbit
- Adds explicit conversion to number in product service getMetadataFrom absoluteOrbit field (as required by the CMRProductMetadata interface definition)