### PR TITLE
DS-4038 Error and warning messages now have a ultra-high z-index so t…

### DIFF
--- a/src/app/components/header/processing-queue/processing-queue.component.ts
+++ b/src/app/components/header/processing-queue/processing-queue.component.ts
@@ -247,11 +247,15 @@ export class ProcessingQueueComponent implements OnInit {
           if (resp.error) {
             if (resp.error.detail === 'No authorization token provided' || resp.error.detail === 'Provided apikey is not valid') {
               this.notificationService.error('Your authorization has expired. Please sign in again.', 'Error', {
-                timeOut: 5000,
+                timeOut: 0,
+                extendedTimeOut: 0,
+                closeButton: true,
             });
             } else {
               this.notificationService.error( resp.error.detail, 'Error', {
-                timeOut: 5000,
+                timeOut: 0,
+                extendedTimeOut: 0,
+                closeButton: true,
               });
             }
           }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,7 +15,7 @@
   top: 115px;
   right: 25px;
   float: right;
-  z-index: 99 !important;
+  //z-index: 99 !important;
 }
 
 // toast style overrides
@@ -24,6 +24,7 @@
   color: $asf-background-white;
   background-color: $asf-blue;
   background-image: url("/assets/icons/check_circle_white_48dp.svg");
+  z-index: 99 !important;
 
   .toast-close-button,
   #toast-container > .toast-close-button {
@@ -40,6 +41,7 @@
   color: $asf-background-white;
   background-color: red;
   background-image: url("/assets/icons/error_white_48dp.svg");
+  z-index: 99999 !important;
 
   .toast-message {
     color: antiquewhite;
@@ -60,6 +62,7 @@
   color: $asf-primary-dark;
   background-color: $asf-background-white;
   background-image: url("/assets/icons/info_black_48dp.svg");
+  z-index: 99 !important;
 
   .toast-message {
     color: $asf-primary;
@@ -75,6 +78,7 @@
   color: $asf-primary-dark;
   background-color: $asf-warn;
   background-image: url("/assets/icons/warning_black_48dp.svg") !important;
+  z-index: 99999 !important;
 
   a {
     color: orangered;


### PR DESCRIPTION
…hey appear over dialogs. Info messages still have a z-index of 99. Also, error messages from the On Demand queue submit action, persist and have a close button.