### PR TITLE
Fix Event Search Results (DS-4083 hotfix)

### DIFF
--- a/src/app/components/results-menu/scene-detail/scene-detail.component.html
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.html
@@ -197,7 +197,9 @@
 
 
   <div style="margin-top: 25px;" class="browse-container w100"
-  *ngIf="!!sarviewsProducts && searchType === searchTypes.SARVIEWS_EVENTS">
+  *ngIf="!!sarviewsProducts
+    && sarviewsProducts?.length > 0
+    && searchType === searchTypes.SARVIEWS_EVENTS">
     <div class="banner" fxLayout fxLayout="row" fxLayoutAlign="center">
       <div class="menu-items">
         <div
@@ -216,7 +218,7 @@
           <mat-icon>download</mat-icon>
         </a>
       </div>
-      <div class="browse-pager" *ngIf="sarviewsProducts">
+      <div class="browse-pager">
         <span
           [class.clickable]="browseIndex > 0"
           (click)="browseIndex > 0 && (browseIndex = browseIndex - 1)"

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -89,6 +89,7 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
     );
 
     const sarviewsEvent$ = this.store$.select(scenesStore.getSelectedSarviewsEvent).pipe(
+      tap(_ => this.browseIndex = 0),
       filter(selectedEvent => !!selectedEvent));
 
 

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -211,13 +211,13 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   }
 
   public onOpenImage(): void {
-    if (!this.sceneHasBrowse()) {
-      return;
-    }
-
     if (this.searchType === models.SearchType.SARVIEWS_EVENTS) {
       this.store$.dispatch(new scenesStore.SetSelectedSarviewProduct(this.sarviewsProducts[this.browseIndex]));
     }
+    else if (!this.sceneHasBrowse()) {
+      return;
+    }
+
     this.store$.dispatch(new uiStore.SetIsBrowseDialogOpen(true));
 
     const dialogRef = this.dialog.open(ImageDialogComponent, {

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -213,8 +213,7 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   public onOpenImage(): void {
     if (this.searchType === models.SearchType.SARVIEWS_EVENTS) {
       this.store$.dispatch(new scenesStore.SetSelectedSarviewProduct(this.sarviewsProducts[this.browseIndex]));
-    }
-    else if (!this.sceneHasBrowse()) {
+    } else if (!this.sceneHasBrowse()) {
       return;
     }
 


### PR DESCRIPTION
Event search results now display properly when first event on load has no products.