### PR TITLE
Subscription Date Error (DS-3978) 

### DIFF
--- a/src/app/components/header/create-subscription/subscription-date-range/subscription-date-range.component.html
+++ b/src/app/components/header/create-subscription/subscription-date-range/subscription-date-range.component.html
@@ -4,5 +4,7 @@
   [startDate]="startDate"
   [endDate]="endDate"
   (newStart)="onStartDateChange($event)"
-  (newEnd)="onEndDateChange($event)" #dateRange>
+  (newEnd)="onEndDateChange($event)"
+  (startDateError)="onStartDateError()"
+  (endDateError)="onEndDateError()" #dateRange>
 </app-date-range>

--- a/src/app/components/header/create-subscription/subscription-date-range/subscription-date-range.component.ts
+++ b/src/app/components/header/create-subscription/subscription-date-range/subscription-date-range.component.ts
@@ -35,14 +35,14 @@ export class SubscriptionDateRangeComponent implements OnInit {
 
   public onStartDateError(): void {
     this.notificationService.error(
-      "subscription must start on today's date or later",
-      "Invalid Start Date")
+      'subscription must start on today\'s date or later',
+      'Invalid Start Date');
   }
 
   public onEndDateError(): void {
     this.notificationService.error(
-      "subscription end date must be within 6 months of start date",
-      "Invalid End Date")
+      'subscription end date must be within 6 months of start date',
+      'Invalid End Date');
   }
 
   private addDays(date: Date, numDays: number): Date {

--- a/src/app/components/header/create-subscription/subscription-date-range/subscription-date-range.component.ts
+++ b/src/app/components/header/create-subscription/subscription-date-range/subscription-date-range.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { NotificationService } from '@services';
 
-import * as models from '@models';
+// import * as models from '@models';
 
 @Component({
   selector: 'app-subscription-date-range',
@@ -17,10 +18,10 @@ export class SubscriptionDateRangeComponent implements OnInit {
   @Output() public newEnd = new EventEmitter<Date>();
   @Output() public newStart = new EventEmitter<Date>();
 
-  constructor() { }
+  constructor(private notificationService: NotificationService) { }
 
   ngOnInit(): void {
-    this.minDate = models.sentinel_1.date.start;
+    this.minDate = new Date();
     this.maxDate = this.addDays(new Date(), 179);
   }
 
@@ -30,6 +31,18 @@ export class SubscriptionDateRangeComponent implements OnInit {
 
   public onEndDateChange(date): void {
     this.newEnd.emit(date);
+  }
+
+  public onStartDateError(): void {
+    this.notificationService.error(
+      "subscription must start on today's date or later",
+      "Invalid Start Date")
+  }
+
+  public onEndDateError(): void {
+    this.notificationService.error(
+      "subscription end date must be within 6 months of start date",
+      "Invalid End Date")
   }
 
   private addDays(date: Date, numDays: number): Date {

--- a/src/app/components/shared/selectors/date-range/date-range.component.ts
+++ b/src/app/components/shared/selectors/date-range/date-range.component.ts
@@ -67,7 +67,7 @@ export class DateRangeComponent implements OnInit, OnDestroy {
 
   public onStartDateChange(e: MatDatepickerInputEvent<Date>): void {
     if (!this.startControl.valid || !e.value) {
-      if(this.isInvalidDateError(this.startControl)) {
+      if (this.isInvalidDateError(this.startControl)) {
         this.invalidDateError$.next(this.startControl);
       } else {
         this.startDateErrors$.next();
@@ -83,7 +83,7 @@ export class DateRangeComponent implements OnInit, OnDestroy {
 
   public onEndDateChange(e: MatDatepickerInputEvent<Date>): void {
     if (!this.endControl.valid || !e.value) {
-      if(this.isInvalidDateError(this.endControl)) {
+      if (this.isInvalidDateError(this.endControl)) {
         this.invalidDateError$.next(this.endControl);
       } else {
         this.endDateErrors$.next();
@@ -156,7 +156,7 @@ export class DateRangeComponent implements OnInit, OnDestroy {
           control
         })),
         tap(({name, control}) => {
-          this.notificationService.error('', "Not a valid date");
+          this.notificationService.error('', 'Not a valid date');
           this.onSetErrorState(name, false);
           this.onSetError(control);
         }),
@@ -174,9 +174,9 @@ export class DateRangeComponent implements OnInit, OnDestroy {
   }
 
   private onSetErrorState(controlName: string, value: boolean) {
-    if(controlName === "StartDateControl") {
+    if (controlName === 'StartDateControl') {
       this.isStartError = value;
-    } else if(controlName === "EndDateControl") {
+    } else if (controlName === 'EndDateControl') {
       this.isEndError = value;
     }
   }


### PR DESCRIPTION
When selecting dates for a new subscriptions, the following cases will throw error messages:
- start date is before the current day
- an end date greater than 6 months (179 days) past the current day

When selecting dates in general, the following will throw an error message:
- Any input that mat-date-picker fails* to parse as a date, such as '####' or "????" 


*Input with a mix of numeric and non-numeric characters can  be interpreted as a date by the date picker, but it will still be ignored