### PR TITLE
fixes event products list missing due to class styling change

### DIFF
--- a/src/app/components/results-menu/scene-files/scene-files.component.html
+++ b/src/app/components/results-menu/scene-files/scene-files.component.html
@@ -46,7 +46,7 @@
       <cdk-virtual-scroll-viewport id="event-selection-list"
                           itemSize="50"
 
-                          class="products-list"
+                          class="products-list event-products"
                           dense role="list">
         <mat-selection-list multiple (selectionChange)="onSelectSarviewsProduct($event)">
           <mat-list-option [value]="prod.product_id" [selected]="!!this.selectedProducts.includes(prod.product_id)"

--- a/src/app/components/results-menu/scene-files/scene-files.component.scss
+++ b/src/app/components/results-menu/scene-files/scene-files.component.scss
@@ -9,6 +9,10 @@ $thumb-size: 50px;
   overflow-y: auto;
 }
 
+.event-products {
+  height: 100%;
+}
+
 .zip-contents {
   padding-bottom: 20px;
 }


### PR DESCRIPTION
Event search products list now visible again, caused by change to css class that all search types used. Separated required styling into event search specific css class.