### PR TITLE
Baseline Scene Detail Tool Bar Styling Fix (DS-4101)

### DIFF
--- a/src/app/components/results-menu/scene-detail/scene-detail.component.html
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.html
@@ -255,7 +255,9 @@
 <div
   class="tool-menu"
   *ngIf="(scene || sarviewEvent) && breakpoint$ | async as breakpoint"
-  [ngStyle]="{ bottom: breakpoint < breakpoints.SMALL ? '17px' : '0' }"
+  [ngStyle]="{ bottom: searchType === searchTypes.BASELINE
+    && breakpoint <= breakpoints.MEDIUM
+    ? '20px' : breakpoint < breakpoints.SMALL ? '17px' : '0' }"
 >
   <div class="search-button-label">SEARCH:</div>
   <div *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"


### PR DESCRIPTION
fixes search tool bar being hidden by credits in baseline search scene details when screen size is between mobile and full breakpoints