### PR TITLE
overlay disclaimer requires less zoom to see on larger frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
-.vscode/launch.json
 !.vscode/extensions.json
 
 # misc

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
-!.vscode/launch.json
+.vscode/launch.json
 !.vscode/extensions.json
 
 # misc

--- a/src/app/services/map/polygon.style.ts
+++ b/src/app/services/map/polygon.style.ts
@@ -1,3 +1,4 @@
+import { Feature } from 'ol';
 import {Circle as CircleStyle, Fill, Stroke, Style, Text} from 'ol/style.js';
 
 export const valid = new Style({
@@ -55,7 +56,7 @@ export const omitted = new Style({
   })
 });
 
-export const invalid = new Style({
+export const invalid = (_: Feature, __: number) => { return new Style({
   text: new Text({
     text: 'Approximate Placement Only',
     scale: 2,
@@ -66,10 +67,8 @@ export const invalid = new Style({
       color: 'rgba(255, 255, 255, 1.0)'
     }),
     placement: 'line',
-    textAlign: 'start',
     textBaseline: 'bottom',
-  overflow: true,
-  padding: [2, 5, 2, 5],
+  overflow: false,
   font: '50px'
   }),
   stroke: new Stroke({
@@ -83,6 +82,7 @@ export const invalid = new Style({
     })
   })
 });
+}
 
 export const hidden = new Style({
   fill: new Fill({

--- a/src/app/services/map/polygon.style.ts
+++ b/src/app/services/map/polygon.style.ts
@@ -1,4 +1,3 @@
-import { Feature } from 'ol';
 import {Circle as CircleStyle, Fill, Stroke, Style, Text} from 'ol/style.js';
 
 export const valid = new Style({
@@ -56,7 +55,7 @@ export const omitted = new Style({
   })
 });
 
-export const invalid = (_: Feature, __: number) => { return new Style({
+export const invalid = new Style({
   text: new Text({
     text: 'Approximate Placement Only',
     scale: 2,
@@ -82,7 +81,6 @@ export const invalid = (_: Feature, __: number) => { return new Style({
     })
   })
 });
-}
 
 export const hidden = new Style({
   fill: new Fill({

--- a/src/app/services/map/polygon.style.ts
+++ b/src/app/services/map/polygon.style.ts
@@ -82,7 +82,7 @@ export const invalid = (_: Feature, __: number) => { return new Style({
     })
   })
 });
-}
+};
 
 export const hidden = new Style({
   fill: new Fill({


### PR DESCRIPTION
Disclaimer positions now automatically chosen by OpenLayers, should now (ideally) choose the most readable orientation.