### PR TITLE
Prod Delivery

### DIFF
--- a/src/app/components/header/processing-queue/processing-options/processing-options.component.html
+++ b/src/app/components/header/processing-queue/processing-options/processing-options.component.html
@@ -34,15 +34,15 @@
             <div *ngIf="jobType.id != 'AUTORIFT'" class="option-header">
               Apply
             </div>
-            <div class="flex-field toggle-list" *ngFor="let option of jobType.options">
-              <app-toggle-option
+            <div class="flex-field checkbox-list" *ngFor="let option of jobType.options">
+              <app-checkbox-option
                 *ngIf="option.type === 'TOGGLE'"
                 (valueChange)="onSetOptionValue(option.apiName, $event)"
                 [value]="optionValues[option.apiName]"
                 [optionName]="option.name"
                 [optionInfo]="option.info"
                 class="margin-right">
-              </app-toggle-option>
+              </app-checkbox-option>
             </div>
           </div>
           <div class="flex-field">

--- a/src/app/components/header/queue/download-all/download-all.component.html
+++ b/src/app/components/header/queue/download-all/download-all.component.html
@@ -1,10 +1,13 @@
-<div [matTooltip]="isDownloadSupported ? disabled ? 'Must be logged in' : 'Download all files in queue' : 'Only available in Chrome'">
+<div [matTooltip]="isDownloadSupported ? disabled ? 'Must be logged in' : 'Download all files in queue' : 'Only available in Chrome'"
+
+>
 <button (click)="downloadAll()"
         mat-menu-item
         style="text-decoration: none;"
         [disabled]="disabled"
 >
 Download All
+<div class="badge">Experimental</div>
 </button>
 </div>
 

--- a/src/app/components/header/queue/download-all/download-all.component.scss
+++ b/src/app/components/header/queue/download-all/download-all.component.scss
@@ -10,3 +10,10 @@ button {
   font-size: 16px;
   color: $color;
 }
+.badge {
+  display: inline;
+  background: #c9cac4;
+  margin: 5px;
+  padding: 5px;
+  border-radius: 50px;
+}

--- a/src/app/components/header/queue/download-all/download-all.component.scss
+++ b/src/app/components/header/queue/download-all/download-all.component.scss
@@ -10,6 +10,7 @@ button {
   font-size: 16px;
   color: $color;
 }
+
 .badge {
   display: inline;
   background: #c9cac4;

--- a/src/app/components/header/queue/queue.component.html
+++ b/src/app/components/header/queue/queue.component.html
@@ -53,10 +53,12 @@
                   <b *ngIf="((product.metadata.fileName | filterExtension) || product.name) as fileName">
                       <span *ngIf="breakpoint !== breakpoints.MOBILE">{{ fileName| truncate: 50 }}</span>
                       <span *ngIf="breakpoint === breakpoints.MOBILE">{{ fileName | truncate: 10 }}</span>
-                      <span *ngIf="product.dataset === 'Sentinel-1B' || product.dataset === 'Sentinel-1A'"
+                      <ng-container *ngIf="fileName.length > (breakpoint !== breakpoints.MOBILE ? 50 : 10)">
+                        <span *ngIf="product.dataset === 'Sentinel-1B' || product.dataset === 'Sentinel-1A'"
                         >{{ fileName.substr(fileName.length - 4) }}</span>
                       <span *ngIf="product.dataset === 'Sentinel-1 Interferogram (BETA)'"
                         >{{ fileName.substr(fileName.length - 11) }}</span>
+                      </ng-container>
                     </b> •
                     <span>
                       <span *ngIf="product.bytes === 0">Virtual</span>

--- a/src/app/components/header/queue/queue.component.html
+++ b/src/app/components/header/queue/queue.component.html
@@ -50,15 +50,14 @@
                 <div matLine
                      class="item-content"
                      [ngClass]="{'dl-list-item-mobile' : breakpoint === breakpoints.MOBILE }">
-                  <b>
-                      <span *ngIf="breakpoint !== breakpoints.MOBILE">{{ product.name | truncate: 50 }}</span>
-                      <span *ngIf="breakpoint === breakpoints.MOBILE">{{ product.name | truncate: 10 }}</span>
+                  <b *ngIf="((product.metadata.fileName | filterExtension) || product.name) as fileName">
+                      <span *ngIf="breakpoint !== breakpoints.MOBILE">{{ fileName| truncate: 50 }}</span>
+                      <span *ngIf="breakpoint === breakpoints.MOBILE">{{ fileName | truncate: 10 }}</span>
                       <span *ngIf="product.dataset === 'Sentinel-1B' || product.dataset === 'Sentinel-1A'"
-                        >{{ product.name.substr(product.name.length - 4) }}</span>
+                        >{{ fileName.substr(fileName.length - 4) }}</span>
                       <span *ngIf="product.dataset === 'Sentinel-1 Interferogram (BETA)'"
-                        >{{ product.name.substr(product.name.length - 11) }}</span>
+                        >{{ fileName.substr(fileName.length - 11) }}</span>
                     </b> •
-
                     <span>
                       <span *ngIf="product.bytes === 0">Virtual</span>
                       <span *ngIf="product.bytes !== 0">{{product.bytes | readableSizeFromBytes }}</span>

--- a/src/app/components/map/map-controls/map-controls.component.html
+++ b/src/app/components/map/map-controls/map-controls.component.html
@@ -85,7 +85,7 @@
 <!--      </div>-->
 
       <!-- Product Browse  -->
-      <div fxFlex="" class="group-margin" *ngIf="searchType !== searchTypes.BASELINE && searchType !== searchTypes.SBAS">
+      <div fxFlex="" class="group-margin" *ngIf="searchType === searchTypes.SARVIEWS_EVENTS">
           <div  fxLayout="row" fxLayoutAlign="center" class="button-group-label" style="white-space: nowrap;">
             <label>Product Browse</label>
           </div>
@@ -99,24 +99,6 @@
                 matTooltip="Unpin All Selected Products">
                 <mat-icon class="control-icon">push_pin</mat-icon>
               </mat-button-toggle>
-              <mat-button-toggle class="control-mat-button-toggle"
-              *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"
-              matTooltipDisabled="!(isBrowseOverlayEnabled$ | async) ? 'Browse Overlays for current scene dataset not available' :
-              'Current Scene only has one available browse'"
-              (click)="onDecrementBrowseIndex()"
-              [disabled]="!(browseIndexingEnabled$ | async)"
-              matTooltip="Change selected scene browse">
-              <mat-icon class="control-icon">arrow_back</mat-icon>
-              </mat-button-toggle>
-                <mat-button-toggle class="control-mat-button-toggle"
-                matTooltipDisabled="!(isBrowseOverlayEnabled$ | async) ? 'Browse Overlays for current scene dataset not available' :
-                  'Current Scene only has one available browse'"
-                *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"
-                (click)="onIncrementBrowseIndex()"
-                [disabled]="!(browseIndexingEnabled$ | async)"
-                matTooltip="Change selected scene browse">
-                <mat-icon class="control-icon">arrow_forward</mat-icon>
-                </mat-button-toggle>
               </mat-button-toggle-group>
           </div>
         </div>

--- a/src/app/components/map/map-controls/map-controls.component.html
+++ b/src/app/components/map/map-controls/map-controls.component.html
@@ -2,168 +2,169 @@
       fxLayout="column"
       fxFill
       cdkDrag>
-
   <div fxLayout="row" class="icon-bar">
-    <div fxLayout="row" fxFlex>
 
-      <div cdkDragHandle class="move-handle">
-        <svg width="24px" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M10 9h4V6h3l-5-5-5 5h3v3zm-1 1H6V7l-5 5 5 5v-3h3v-4zm14 2l-5-5v3h-3v4h3v3l5-5zm-9 3h-4v3H7l5 5 5-5h-3v-3z"></path>
-          <path d="M0 0h24v24H0z" fill="none"></path>
-        </svg>
-      </div>
+    <div fxLayout="column" fxFlex>
 
-      <div fxFlex="" class="group-margin" *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS">
-        <div fxLayout="row" fxLayoutAlign="left" class="button-group-label">
-          <label>&nbsp;Map View</label>
+      <div fxLayout="row">
+
+
+        <div cdkDragHandle class="move-handle-div"  fxFlex="">
+          <svg class="move-handle" width="24px" fill="rgb(101, 102, 92)" viewBox="0 0 24 24">
+            <path d="M10 9h4V6h3l-5-5-5 5h3v3zm-1 1H6V7l-5 5 5 5v-3h3v-4zm14 2l-5-5v3h-3v4h3v3l5-5zm-9 3h-4v3H7l5 5 5-5h-3v-3z"></path>
+            <path d="M0 0h24v24H0z" fill="none"></path>
+          </svg>
+          <div class="move-handle-bottom"></div>
         </div>
 
-        <div fxLayout="row">
-          <app-view-selector fxFlex="">
-          </app-view-selector>
-        </div>
-      </div>
+        <div *ngIf="showToolBar == true" fxLayout="column" class="visible-toggle">
+          <div fxLayout="row" class="icon-bar">
 
-      <div fxFlex="" class="zoom-buttons">
-        <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
-          <label>Zoom</label>
-        </div>
-        <div fxLayout="row">
-          <div>
-            <mat-button-toggle-group fxFlex="" name="layerType">
-              <mat-button-toggle class="control-mat-button-toggle"
-                                 (click)="zoomIn()"
-                                 matTooltip="Zoom In">
-                <mat-icon class="control-icon">add</mat-icon>
-              </mat-button-toggle>
+            <div fxFlex="" class="group-margin" *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS">
+              <div fxLayout="row" fxLayoutAlign="left" class="button-group-label">
+                <label>&nbsp;Map View</label>
+              </div>
 
-              <mat-button-toggle class="control-mat-button-toggle"
-                                 (click)="zoomOut()"
-                                 matTooltip="Zoom out">
-                <mat-icon class="control-icon">remove</mat-icon>
-              </mat-button-toggle>
-            </mat-button-toggle-group>
-          </div>
-        </div>
-      </div>
-
-      <div *ngIf="(view$ | async) === viewTypes.EQUITORIAL" fxFlex="" class="group-margin">
-        <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
-          <label>Layers</label>
-        </div>
-        <div fxLayout="row">
-          <app-layer-selector></app-layer-selector>
-        </div>
-      </div>
-
-<!--      <div fxFlex="" class="group-margin" [hidden]="(view$ | async) !== viewTypes.EQUITORIAL">-->
-<!--        <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">-->
-<!--          <label>Gridlines</label>-->
-<!--        </div>-->
-<!--        <div fxLayout="row">-->
-<!--          <app-gridlines-selector></app-gridlines-selector>-->
-<!--        </div>-->
-<!--      </div>-->
-
-      <div *ngIf="searchType === searchTypes.DATASET || searchType === searchTypes.SBAS" fxFlex="" class="group-margin">
-        <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
-          <label>Area of Interest</label>
-        </div>
-        <div fxLayout="row">
-          <app-interaction-selector>
-          </app-interaction-selector>
-        </div>
-      </div>
-
-<!--      <div *ngIf="searchType === searchTypes.DATASET || searchType === searchTypes.SBAS" fxFlex="" class="group-margin">-->
-<!--        <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">-->
-<!--          <label>Selection Shape</label>-->
-<!--        </div>-->
-<!--        <div fxLayout="row">-->
-<!--          <app-draw-selector></app-draw-selector>-->
-<!--        </div>-->
-<!--      </div>-->
-
-      <!-- Product Browse  -->
-      <div fxFlex="" class="group-margin" *ngIf="searchType !== searchTypes.BASELINE && searchType !== searchTypes.SBAS">
-          <div  fxLayout="row" fxLayoutAlign="center" class="button-group-label" style="white-space: nowrap;">
-            <label>Product Browse</label>
-          </div>
-          <div fxLayout="row" fxLayoutAlign="center">
-            <div>
-              <mat-button-toggle-group fxFlex="" name="layerType"
-              [disabled]="!(isBrowseOverlayEnabled$ | async)">
-                <mat-button-toggle class="control-mat-button-toggle"
-                *ngIf="searchType === searchTypes.SARVIEWS_EVENTS"
-                (click)="onUnpinAll()"
-                matTooltip="Unpin All Selected Products">
-                <mat-icon class="control-icon">push_pin</mat-icon>
-              </mat-button-toggle>
-              <mat-button-toggle class="control-mat-button-toggle"
-              *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"
-              matTooltipDisabled="!(isBrowseOverlayEnabled$ | async) ? 'Browse Overlays for current scene dataset not available' :
-              'Current Scene only has one available browse'"
-              (click)="onDecrementBrowseIndex()"
-              [disabled]="!(browseIndexingEnabled$ | async)"
-              matTooltip="Change selected scene browse">
-              <mat-icon class="control-icon">arrow_back</mat-icon>
-              </mat-button-toggle>
-                <mat-button-toggle class="control-mat-button-toggle"
-                matTooltipDisabled="!(isBrowseOverlayEnabled$ | async) ? 'Browse Overlays for current scene dataset not available' :
-                  'Current Scene only has one available browse'"
-                *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"
-                (click)="onIncrementBrowseIndex()"
-                [disabled]="!(browseIndexingEnabled$ | async)"
-                matTooltip="Change selected scene browse">
-                <mat-icon class="control-icon">arrow_forward</mat-icon>
-                </mat-button-toggle>
-              </mat-button-toggle-group>
-          </div>
-        </div>
-      </div>
-
-      <!-- Opacity Control -->
-      <div fxFlex="" class="group-margin" *ngIf="searchType !== searchTypes.BASELINE && searchType !== searchTypes.SBAS">
-        <div  fxLayout="row" fxLayoutAlign="center" class="button-group-label">
-          <label>Opacity</label>
-        </div>
-        <div fxLayout="row">
-          <button mat-stroked-button class="opacity-slider-button"
-                  [disabled]="!(isBrowseOverlayEnabled$ | async)"
-                  [matMenuTriggerFor]="opacitySlider"
-                  aria-label="Map projection view">
-            <span class="opacity-button-text">{{ browseOverlayOpacity * 100 | number : '1.0-0' }}%</span>
-            <span class="fa fa-caret-down bottom-right"></span>
-          </button>
-          <mat-menu #opacitySlider="matMenu" class="opacity-slider-mat-menu">
-            <div class="opacity-slider-title">
-              Opacity of Browse Images
+              <div fxLayout="row">
+                <app-view-selector fxFlex="">
+                </app-view-selector>
+              </div>
             </div>
-            <mat-slider thumbLabel tickInterval="0.1" step="0.05" value="1" min="0.0" max="1.0"
-                        class="opacity-slider"
-                        name="layerType"
-                        (input)="onSetOpacity($event)"
+
+            <div fxFlex="" class="zoom-buttons">
+              <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
+                <label>Zoom</label>
+              </div>
+              <div fxLayout="row">
+                <div>
+                  <mat-button-toggle-group fxFlex="" name="layerType">
+                    <mat-button-toggle class="control-mat-button-toggle"
+                                       (click)="zoomIn()"
+                                       matTooltip="Zoom In">
+                      <mat-icon class="control-icon">add</mat-icon>
+                    </mat-button-toggle>
+
+                    <mat-button-toggle class="control-mat-button-toggle"
+                                       (click)="zoomOut()"
+                                       matTooltip="Zoom out">
+                      <mat-icon class="control-icon">remove</mat-icon>
+                    </mat-button-toggle>
+                  </mat-button-toggle-group>
+                </div>
+              </div>
+            </div>
+
+            <div *ngIf="(view$ | async) === viewTypes.EQUITORIAL" fxFlex="" class="group-margin">
+              <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
+                <label>Layers</label>
+              </div>
+              <div fxLayout="row">
+                <app-layer-selector></app-layer-selector>
+              </div>
+            </div>
+
+            <div *ngIf="searchType === searchTypes.DATASET || searchType === searchTypes.SBAS" fxFlex="" class="group-margin">
+              <div fxLayout="row" fxLayoutAlign="center" class="button-group-label">
+                <label>Area of Interest</label>
+              </div>
+              <div fxLayout="row">
+                <app-interaction-selector>
+                </app-interaction-selector>
+              </div>
+            </div>
+
+            <!-- Product Browse  -->
+            <div fxFlex="" class="group-margin" *ngIf="searchType !== searchTypes.BASELINE && searchType !== searchTypes.SBAS">
+              <div  fxLayout="row" fxLayoutAlign="center" class="button-group-label" style="white-space: nowrap;">
+                <label>Product Browse</label>
+              </div>
+              <div fxLayout="row" fxLayoutAlign="center">
+                <div>
+                  <mat-button-toggle-group fxFlex="" name="layerType"
+                                           [disabled]="!(isBrowseOverlayEnabled$ | async)">
+                    <mat-button-toggle class="control-mat-button-toggle"
+                                       *ngIf="searchType === searchTypes.SARVIEWS_EVENTS"
+                                       (click)="onUnpinAll()"
+                                       matTooltip="Unpin All Selected Products">
+                      <mat-icon class="control-icon">push_pin</mat-icon>
+                    </mat-button-toggle>
+                    <mat-button-toggle class="control-mat-button-toggle"
+                                       *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"
+                                       matTooltipDisabled="!(isBrowseOverlayEnabled$ | async) ? 'Browse Overlays for current scene dataset not available' :
+                'Current Scene only has one available browse'"
+                                       (click)="onDecrementBrowseIndex()"
+                                       [disabled]="!(browseIndexingEnabled$ | async)"
+                                       matTooltip="Change selected scene browse">
+                      <mat-icon class="control-icon">arrow_back</mat-icon>
+                    </mat-button-toggle>
+                    <mat-button-toggle class="control-mat-button-toggle"
+                                       matTooltipDisabled="!(isBrowseOverlayEnabled$ | async) ? 'Browse Overlays for current scene dataset not available' :
+                    'Current Scene only has one available browse'"
+                                       *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS"
+                                       (click)="onIncrementBrowseIndex()"
+                                       [disabled]="!(browseIndexingEnabled$ | async)"
+                                       matTooltip="Change selected scene browse">
+                      <mat-icon class="control-icon">arrow_forward</mat-icon>
+                    </mat-button-toggle>
+                  </mat-button-toggle-group>
+                </div>
+              </div>
+            </div>
+
+            <!-- Opacity Control -->
+            <div fxFlex="" class="group-margin" *ngIf="searchType !== searchTypes.BASELINE && searchType !== searchTypes.SBAS">
+              <div  fxLayout="row" fxLayoutAlign="center" class="button-group-label">
+                <label>Opacity</label>
+              </div>
+              <div fxLayout="row">
+                <button mat-stroked-button class="opacity-slider-button"
                         [disabled]="!(isBrowseOverlayEnabled$ | async)"
-                        [matTooltip]="(isBrowseOverlayEnabled$ | async) ? 'Adjust Overlay Opacity' :
-                             'Product Overlays for current scene dataset not available'"
-            >
-            </mat-slider>
-          </mat-menu>
+                        [matMenuTriggerFor]="opacitySlider"
+                        aria-label="Map projection view">
+                  <span class="opacity-button-text">{{ browseOverlayOpacity * 100 | number : '1.0-0' }}%</span>
+                  <span class="fa fa-caret-down bottom-right"></span>
+                </button>
+                <mat-menu #opacitySlider="matMenu" class="opacity-slider-mat-menu">
+                  <div class="opacity-slider-title">
+                    Opacity of Browse Images
+                  </div>
+                  <mat-slider thumbLabel tickInterval="0.1" step="0.05" value="1" min="0.0" max="1.0"
+                              class="opacity-slider"
+                              name="layerType"
+                              (input)="onSetOpacity($event)"
+                              [disabled]="!(isBrowseOverlayEnabled$ | async)"
+                              [matTooltip]="(isBrowseOverlayEnabled$ | async) ? 'Adjust Overlay Opacity' :
+                               'Product Overlays for current scene dataset not available'"
+                  >
+                  </mat-slider>
+                </mat-menu>
+              </div>
+            </div>
+
+            <div fxFlex="20px"></div>
+
+          </div>
+          <div fxFlex="" class="lat-lon">
+            <div fxFlex="" fxFlexAlign="end">
+              <div fxFlex="75px" class="lat-lon-data">
+                <b>lat</b> {{ mousePos?.lat | number : '2.1-4' }}°
+              </div>
+              <div fxFlex="85px">
+                <b>lon</b> {{ mousePos?.lon | number : '2.1-4' }}°
+              </div>
+            </div>
+            <div fxFlex="grow"></div>
+          </div>
         </div>
       </div>
 
     </div>
+    <div class="tool-bar-control"
+         (click)="changeState()">
+      <div *ngIf="showToolBar == true"><mat-icon>arrow_back_ios</mat-icon></div>
+      <div *ngIf="showToolBar == false"><mat-icon>arrow_forward_ios</mat-icon></div>
+      <div class="tool-bar-control-bottom"></div>
+    </div>
   </div>
 
-  <div fxLayout="row" fxFlex class="lat-lon">
-    <div fxFlex="" fxFlexAlign="end">
-      <div fxFlex="75px" class="lat-lon-data">
-        <b>lat</b> {{ mousePos?.lat | number : '2.1-4' }}°
-      </div>
-      <div fxFlex="85px">
-        <b>lon</b> {{ mousePos?.lon | number : '2.1-4' }}°
-      </div>
-    </div>
-    <div fxFlex="grow"></div>
-  </div>
 </div>

--- a/src/app/components/map/map-controls/map-controls.component.html
+++ b/src/app/components/map/map-controls/map-controls.component.html
@@ -8,17 +8,8 @@
 
       <div fxLayout="row">
 
-
-        <div cdkDragHandle class="move-handle-div"  fxFlex="">
-          <svg class="move-handle" width="24px" fill="rgb(101, 102, 92)" viewBox="0 0 24 24">
-            <path d="M10 9h4V6h3l-5-5-5 5h3v3zm-1 1H6V7l-5 5 5 5v-3h3v-4zm14 2l-5-5v3h-3v4h3v3l5-5zm-9 3h-4v3H7l5 5 5-5h-3v-3z"></path>
-            <path d="M0 0h24v24H0z" fill="none"></path>
-          </svg>
-          <div class="move-handle-bottom"></div>
-        </div>
-
         <div *ngIf="showToolBar == true" fxLayout="column" class="visible-toggle">
-          <div fxLayout="row" class="icon-bar">
+          <div fxLayout="row" class="icon-bar tool-bar-common">
 
             <div fxFlex="" class="group-margin" *ngIf="searchType !== searchTypes.SARVIEWS_EVENTS">
               <div fxLayout="row" fxLayoutAlign="left" class="button-group-label">
@@ -141,8 +132,6 @@
               </div>
             </div>
 
-            <div fxFlex="20px"></div>
-
           </div>
           <div fxFlex="" class="lat-lon">
             <div fxFlex="" fxFlexAlign="end">
@@ -161,9 +150,9 @@
     </div>
     <div class="tool-bar-control"
          (click)="changeState()">
-      <div *ngIf="showToolBar == true"><mat-icon>arrow_back_ios</mat-icon></div>
-      <div *ngIf="showToolBar == false"><mat-icon>arrow_forward_ios</mat-icon></div>
-      <div class="tool-bar-control-bottom"></div>
+      <div *ngIf="showToolBar == true"><mat-icon>arrow_circle_left</mat-icon></div>
+      <div *ngIf="showToolBar == false"><mat-icon>arrow_circle_right</mat-icon></div>
+      <div class="tool-bar-control-bottom visible-toggle"></div>
     </div>
   </div>
 

--- a/src/app/components/map/map-controls/map-controls.component.scss
+++ b/src/app/components/map/map-controls/map-controls.component.scss
@@ -156,7 +156,8 @@ label {
   width: calc(100% + 10px);
   margin: 3px 0 0 -10px;
   height: 14px;
-  background-color: #65665c;}
+  background-color: #65665c;
+}
 
 .visible-toggle {
   transition: all 1.2s ease-in-out;

--- a/src/app/components/map/map-controls/map-controls.component.scss
+++ b/src/app/components/map/map-controls/map-controls.component.scss
@@ -9,7 +9,7 @@ $info-color: $asf-primary;
 
 .position {
   z-index: 998;
-  margin-left: 5px;
+  margin-left: 0;
   top: 20px;
   width: 100%;
   height: 100%;
@@ -39,6 +39,7 @@ label {
   background-color: $asf-primary;
   color: $asf-primary-light;
   margin-top: 0;
+  padding-left: 10px;
   max-height: 14px !important;
 }
 
@@ -146,20 +147,23 @@ label {
   display: block;
   width: 30px;
   padding: 14px 0;
+  margin-left: 10px;
   color: $asf-primary;
   background-color: $asf-primary-light;
 }
 
 .tool-bar-control-bottom {
-  width: 100%;
-  margin: 3px 0;
+  width: calc(100% + 10px);
+  margin: 3px 0 0 -10px;
   height: 14px;
-  background-color: $asf-primary;
-}
+  background-color: #65665c;}
 
 .visible-toggle {
   transition: all 1.2s ease-in-out;
-  //height: 45px;
+}
+
+.tool-bar-common {
+  margin-left: 10px;
 }
 
 ::ng-deep .mat-slider.mat-slider-horizontal {

--- a/src/app/components/map/map-controls/map-controls.component.scss
+++ b/src/app/components/map/map-controls/map-controls.component.scss
@@ -18,8 +18,9 @@ $info-color: $asf-primary;
 .icon-bar {
   background-color: $info-background;
   padding: 0;
-  padding-right: 4px;
   pointer-events: auto;
+  height: 45px !important;
+  max-height: 45px !important;
 }
 
 .ribbon-info-top {
@@ -37,11 +38,12 @@ label {
   font-size: 12px;
   background-color: $asf-primary;
   color: $asf-primary-light;
-  //margin-top: -3px;
+  margin-top: 0;
+  max-height: 14px !important;
 }
 
 .lat-lon-data {
-  margin-left: 41px;
+  margin-left: 8px;
 }
 
 .group-margin {
@@ -63,14 +65,25 @@ label {
   color: $info-color;
 }
 
+.move-handle-div {
+  background-color: $asf-primary-light;
+  cursor: move;
+}
+
 .move-handle {
   margin-top: 16px;
   margin-left: 7px;
   margin-right: 7px;
-  color: $info-color;
+  color: $asf-primary-dark;
   cursor: move;
   width: 24px;
   height: 24px;
+}
+
+.move-handle-bottom {
+  background-color: $asf-primary;
+  height: 14px;
+  margin-top: 1px;
 }
 
 .slim-line {
@@ -126,6 +139,27 @@ label {
   color: $asf-primary;
   text-align: center;
   align-content: center;
+}
+
+.tool-bar-control {
+  cursor: pointer;
+  display: block;
+  width: 30px;
+  padding: 14px 0;
+  color: $asf-primary;
+  background-color: $asf-primary-light;
+}
+
+.tool-bar-control-bottom {
+  width: 100%;
+  margin: 3px 0;
+  height: 14px;
+  background-color: $asf-primary;
+}
+
+.visible-toggle {
+  transition: all 1.2s ease-in-out;
+  //height: 45px;
 }
 
 ::ng-deep .mat-slider.mat-slider-horizontal {

--- a/src/app/components/map/map-controls/map-controls.component.ts
+++ b/src/app/components/map/map-controls/map-controls.component.ts
@@ -35,6 +35,8 @@ export class MapControlsComponent implements OnInit, OnDestroy {
   public viewTypes = models.MapViewType;
   public mousePos: LonLat;
   public browseOverlayOpacity: number;
+  public showToolBar = true;
+  public toolBarWidth = 571;
 
   private subs = new SubSink();
   private selectedEventProducts: SarviewsProduct[] = [];
@@ -155,6 +157,16 @@ export class MapControlsComponent implements OnInit, OnDestroy {
 
   public onNewProjection(view: models.MapViewType): void {
     this.store$.dispatch(new mapStore.SetMapView(view));
+  }
+
+  public changeState(): void {
+    if (this.toolBarWidth === 0) {
+      this.toolBarWidth = 571;
+      this.showToolBar = true;
+    } else {
+      this.toolBarWidth = 0;
+      this.showToolBar = false;
+    }
   }
 
   public zoomIn(): void {

--- a/src/app/components/map/map-controls/map-controls.component.ts
+++ b/src/app/components/map/map-controls/map-controls.component.ts
@@ -16,7 +16,6 @@ import { combineLatest, Observable } from 'rxjs';
 import { filter, map, startWith, tap } from 'rxjs/operators';
 import { ToggleBrowseOverlay} from '@store/map';
 import { MatSliderChange } from '@angular/material/slider';
-import { getSelectedDatasetId } from '@store/filters';
 
 @Component({
   selector: 'app-map-controls',
@@ -52,35 +51,7 @@ export class MapControlsComponent implements OnInit, OnDestroy {
     filter(event => !!event),
   startWith(null));
 
-  public isBrowseOverlayEnabled$: Observable<boolean> = combineLatest([
-    this.store$.select(searchStore.getSearchType),
-    this.store$.select(sceneStore.getSelectedScene),
-    this.store$.select(getSelectedDatasetId),
-      this.store$.select(sceneStore.getSelectedSarviewsEventProducts)]
-    ).pipe(
-      map(([searchtype, selectedScene, datasetID, selectedEventProducts]) => {
-        switch (searchtype) {
-          case models.SearchType.DATASET:
-            return datasetID === 'AVNIR'
-            || datasetID === 'SENTINEL-1'
-            || datasetID === 'SENTINEL-1 INTERFEROGRAM (BETA)'
-            || datasetID === 'UAVSAR';
-          case models.SearchType.SARVIEWS_EVENTS:
-            return selectedEventProducts?.length > 0;
-          case models.SearchType.LIST:
-            return selectedScene?.dataset === 'ALOS'
-            || selectedScene?.dataset === 'Sentinel-1A'
-            || selectedScene?.dataset === 'Sentinel-1B'
-            || selectedScene?.dataset === 'Sentinel-1 Interferogram (BETA)'
-            || selectedScene?.dataset === 'UAVSAR';
-          case models.SearchType.CUSTOM_PRODUCTS:
-            return true;
-          default:
-            return false;
-
-        }
-      }),
-    );
+  public isBrowseOverlayEnabled$: Observable<boolean> = this.browseOverlayService.isBrowseOverlayEnabled$;
 
   public browseIndexingEnabled$ = combineLatest([
     this.isBrowseOverlayEnabled$,
@@ -92,6 +63,7 @@ export class MapControlsComponent implements OnInit, OnDestroy {
   constructor(
     private store$: Store<AppState>,
     private mapService: services.MapService,
+    private browseOverlayService: services.BrowseOverlayService
   ) { }
 
   ngOnInit() {

--- a/src/app/components/map/map-controls/map-controls.component.ts
+++ b/src/app/components/map/map-controls/map-controls.component.ts
@@ -130,9 +130,9 @@ export class MapControlsComponent implements OnInit, OnDestroy {
 
     this.subs.add(
       this.store$.select(sceneStore.getSelectedSarviewsEventProducts)
-      .pipe(filter(event => !!event))
+      .pipe(filter(eventProducts => !!eventProducts))
       .subscribe(
-        event => this.selectedEventProducts = event
+        eventProducts => this.selectedEventProducts = eventProducts
       )
     );
 

--- a/src/app/components/map/map.component.html
+++ b/src/app/components/map/map.component.html
@@ -91,14 +91,6 @@
   id="popup" class="ol-popup" #overlay>
 </div>
 
-
-<!-- <div #sarviewPopupContainer style="width: 150px; height: 150px; background-color: white; border-radius: 12px;">
-<p>
-  {{selectedSarviewEvent?.description}}
-</p>
-  <button mat-button><a target="_blank" href="{{'https://sarviews-hazards.alaska.edu/Event/' + selectedSarviewEvent?.event_id}}">SARVIEWS Event Page</a></button>
-</div> -->
-
 <div #browsetooltip style="width: 100px; height: 100px;">
 TOOLTIP
 </div>

--- a/src/app/components/map/map.component.scss
+++ b/src/app/components/map/map.component.scss
@@ -7,7 +7,7 @@
 
 .map-header {
   position: relative;
-  top: 5px;
+  top: 12px;
   width: 100vw;
   pointer-events: none;
 }
@@ -22,7 +22,6 @@
 }
 
 .map-controls {
-  padding-right: 15px;
   height: 58px;
 }
 

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.html
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.html
@@ -155,7 +155,7 @@
                 <span
                   class="navigation-icon"
                   [class.clickable]="browseIndex > 0"
-                  (click)="browseIndex > 0 && (browseIndex = browseIndex - 1)"
+                  (click)="onIncrementBrowseIndex()"
                 >
                   <mat-icon [class.not-clickable]="browseIndex < 1"
                     >navigate_before</mat-icon
@@ -165,10 +165,7 @@
                 <span
                   class="navigation-icon"
                   [class.clickable]="browseIndex + 1 < browses.length"
-                  (click)="
-                    browseIndex + 1 < browses.length &&
-                      (browseIndex = browseIndex + 1)
-                  "
+                  (click)=onDecrementBrowseIndex()
                 >
                   <mat-icon
                     [class.not-clickable]="browseIndex + 1 >= browses.length"
@@ -217,23 +214,31 @@
         >
           <mat-icon>download</mat-icon>
         </a>
+        <span
+        class ="clickable"
+        matTooltip="Pin this product's browse on the map"
+        (click)="onToggleSarviewsProductPin()"
+        >
+          <mat-icon>
+            push_pin
+          </mat-icon>
+        </span>
       </div>
       <div class="browse-pager">
         <span
           [class.clickable]="browseIndex > 0"
-          (click)="browseIndex > 0 && (browseIndex = browseIndex - 1)"
+          (click)="onDecrementBrowseIndex()"
         >
-          <mat-icon>arrow_back</mat-icon>
+          <mat-icon>navigate_before</mat-icon>
         </span>
         {{ browseIndex + 1 }} / {{ sarviewsProducts.length }}
         <span
           [class.clickable]="browseIndex + 1 < sarviewsProducts.length"
           (click)="
-            browseIndex + 1 < sarviewsProducts.length &&
-              (browseIndex = browseIndex + 1)
+          onIncrementBrowseIndex()
           "
         >
-          <mat-icon>arrow_forward</mat-icon>
+          <mat-icon>navigate_next</mat-icon>
         </span>
       </div>
     </div>

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.html
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.html
@@ -155,7 +155,7 @@
                 <span
                   class="navigation-icon"
                   [class.clickable]="browseIndex > 0"
-                  (click)="onIncrementBrowseIndex()"
+                  (click)="onDecrementBrowseIndex()"
                 >
                   <mat-icon [class.not-clickable]="browseIndex < 1"
                     >navigate_before</mat-icon
@@ -165,7 +165,7 @@
                 <span
                   class="navigation-icon"
                   [class.clickable]="browseIndex + 1 < browses.length"
-                  (click)=onDecrementBrowseIndex()
+                  (click)=onIncrementBrowseIndex()
                 >
                   <mat-icon
                     [class.not-clickable]="browseIndex + 1 >= browses.length"
@@ -229,7 +229,9 @@
           [class.clickable]="browseIndex > 0"
           (click)="onDecrementBrowseIndex()"
         >
-          <mat-icon>navigate_before</mat-icon>
+          <mat-icon
+          [class.not-clickable]="browseIndex < 1"
+          >navigate_before</mat-icon>
         </span>
         {{ browseIndex + 1 }} / {{ sarviewsProducts.length }}
         <span
@@ -238,7 +240,9 @@
           onIncrementBrowseIndex()
           "
         >
-          <mat-icon>navigate_next</mat-icon>
+          <mat-icon
+          [class.not-clickable]="browseIndex + 1 >= sarviewsProducts?.length"
+          >navigate_next</mat-icon>
         </span>
       </div>
     </div>

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -267,7 +267,7 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   }
 
   public onIncrementBrowseIndex() {
-    if(this.browseIndex === this.getBrowseCount() - 1) {
+    if (this.browseIndex === this.getBrowseCount() - 1) {
       return;
     }
     const newIndex = this.browseIndex + 1;
@@ -275,7 +275,7 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   }
 
   public onDecrementBrowseIndex() {
-    if(this.browseIndex === 0) {
+    if (this.browseIndex === 0) {
       return;
     }
     const newIndex = this.browseIndex - 1;
@@ -283,7 +283,7 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   }
 
   public onUpdateBrowseIndex(newIndex: number) {
-    if(!this.isBrowseOverlayEnabled) {
+    if (!this.isBrowseOverlayEnabled) {
       return;
     }
 
@@ -296,17 +296,17 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   }
 
   public onToggleSarviewsProductPin() {
-    if(this.selectedEventProducts?.length === 0) {
+    if (this.selectedEventProducts?.length === 0) {
       return;
     }
 
     const currentProductId = this.selectedEventProducts[this.browseIndex].product_id;
-    const isPinned = this.eventSelectedProductIds.includes(currentProductId)
+    const isPinned = this.eventSelectedProductIds.includes(currentProductId);
 
-    if(isPinned) {
-      this.eventSelectedProductIds = this.eventSelectedProductIds.filter(productId => productId !== currentProductId)
+    if (isPinned) {
+      this.eventSelectedProductIds = this.eventSelectedProductIds.filter(productId => productId !== currentProductId);
     } else {
-      this.eventSelectedProductIds.push(currentProductId)
+      this.eventSelectedProductIds.push(currentProductId);
     }
     this.onUpdatePinnedUrl(this.eventSelectedProductIds);
   }

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -12,13 +12,14 @@ import * as uiStore from '@store/ui';
 import * as userStore from '@store/user';
 
 import * as models from '@models';
-import { AuthService, MapService, PropertyService,
+import { AuthService, BrowseOverlayService, MapService, PropertyService,
    SarviewsEventsService,
   ScreenSizeService } from '@services';
 import { ImageDialogComponent } from './image-dialog';
 
 import { DatasetForProductService } from '@services';
 import { PinnedProduct } from '@services/browse-map.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-scene-detail',
@@ -59,6 +60,9 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   private defaultSBASFiltersID = '';
 
   public sarviewsProducts: models.SarviewsProduct[] = [];
+  public isBrowseOverlayEnabled$: Observable<boolean> = this.browseOverlayService.isBrowseOverlayEnabled$;
+
+  public isBrowseOverlayEnabled = false;
 
   private subs = new SubSink();
 
@@ -71,9 +75,16 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
     private datasetForProduct: DatasetForProductService,
     private sarviewsService: SarviewsEventsService,
     private mapService: MapService,
+    private browseOverlayService: BrowseOverlayService
   ) {}
 
   ngOnInit() {
+    this.subs.add(
+      this.isBrowseOverlayEnabled$.subscribe(
+        enabled => this.isBrowseOverlayEnabled = enabled
+      )
+    );
+
     this.subs.add(
       this.store$.select(userStore.getIsUserLoggedIn).subscribe(
         isLoggedIn => this.isLoggedIn = isLoggedIn
@@ -272,6 +283,10 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   }
 
   public onUpdateBrowseIndex(newIndex: number) {
+    if(!this.isBrowseOverlayEnabled) {
+      return;
+    }
+
     this.browseIndex = newIndex;
     const [url, wkt] = this.searchType === this.searchTypes.SARVIEWS_EVENTS
     ? [this.selectedEventProducts[this.browseIndex].files.browse_url, this.selectedEventProducts[this.browseIndex]?.granules[0].wkt]

--- a/src/app/components/shared/aoi-options/draw-selector/draw-selector.component.html
+++ b/src/app/components/shared/aoi-options/draw-selector/draw-selector.component.html
@@ -69,4 +69,3 @@
     Upload Geospatial File
   </button>
 </mat-menu>
-

--- a/src/app/components/shared/aoi-options/interaction-selector/interaction-selector.component.html
+++ b/src/app/components/shared/aoi-options/interaction-selector/interaction-selector.component.html
@@ -26,10 +26,5 @@
     #clearButton>
     <mat-icon class="interaction-icon">delete</mat-icon>
   </mat-button-toggle>
-<!--  <mat-button-toggle-->
-<!--    (click)="onImportSelected()"-->
-<!--    class="control-mat-button-toggle"-->
-<!--    matTooltip="Import Area of Interest">-->
-<!--    <mat-icon class="interaction-icon">upload</mat-icon>-->
-<!--  </mat-button-toggle>-->
+
 </mat-button-toggle-group>

--- a/src/app/pipes/filter-extension.pipe.ts
+++ b/src/app/pipes/filter-extension.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'filterExtension'
+})
+export class FilterExtensionPipe implements PipeTransform {
+    transform(input: string): string {
+        return input?.split('.')[0];
+    }
+}

--- a/src/app/pipes/pipes.module.ts
+++ b/src/app/pipes/pipes.module.ts
@@ -7,6 +7,7 @@ import { JoinPipe } from './join.pipe';
 import { BaselineFilterPipe, SBASFilterPipe, GeographicFilterPipe, ListFilterPipe } from './filter-type.pipe';
 import { HTMLInputValuePipe } from './html-input-value.pipe';
 import { QuakePipe, VolcanoPipe } from './sarviews-event.pipe';
+import { FilterExtensionPipe } from './filter-extension.pipe';
 @NgModule({
   declarations: [
     ReadableSizeFromBytesPipe,
@@ -21,6 +22,7 @@ import { QuakePipe, VolcanoPipe } from './sarviews-event.pipe';
     HTMLInputValuePipe,
     QuakePipe,
     VolcanoPipe,
+    FilterExtensionPipe
     // floodPipe
   ],
   imports: [
@@ -39,6 +41,7 @@ import { QuakePipe, VolcanoPipe } from './sarviews-event.pipe';
     HTMLInputValuePipe,
     QuakePipe,
     VolcanoPipe,
+    FilterExtensionPipe,
     // floodPipe,
   ]
 })

--- a/src/app/services/browse-overlay.service.ts
+++ b/src/app/services/browse-overlay.service.ts
@@ -27,6 +27,36 @@ import { AppState } from '@store';
 })
 export class BrowseOverlayService {
 
+  public isBrowseOverlayEnabled$: Observable<boolean> = combineLatest([
+    this.store$.select(searchStore.getSearchType),
+    this.store$.select(sceneStore.getSelectedScene),
+    this.store$.select(filtersStore.getSelectedDatasetId),
+      this.store$.select(sceneStore.getSelectedSarviewsEventProducts)]
+    ).pipe(
+      map(([searchtype, selectedScene, datasetID, selectedEventProducts]) => {
+        switch (searchtype) {
+          case models.SearchType.DATASET:
+            return datasetID === 'AVNIR'
+            || datasetID === 'SENTINEL-1'
+            || datasetID === 'SENTINEL-1 INTERFEROGRAM (BETA)'
+            || datasetID === 'UAVSAR';
+          case models.SearchType.SARVIEWS_EVENTS:
+            return selectedEventProducts?.length > 0;
+          case models.SearchType.LIST:
+            return selectedScene?.dataset === 'ALOS'
+            || selectedScene?.dataset === 'Sentinel-1A'
+            || selectedScene?.dataset === 'Sentinel-1B'
+            || selectedScene?.dataset === 'Sentinel-1 Interferogram (BETA)'
+            || selectedScene?.dataset === 'UAVSAR';
+          case models.SearchType.CUSTOM_PRODUCTS:
+            return true;
+          default:
+            return false;
+
+        }
+    }),
+  );
+
   constructor(private wktService: WktService,
     private store$: Store<AppState>) { }
 
@@ -123,36 +153,6 @@ export class BrowseOverlayService {
       (geom as Polygon).setCoordinates([this.wktService.fixAntimeridianCoordinates(polygonCoordinates)]);
     }
   }
-
-  public isBrowseOverlayEnabled$: Observable<boolean> = combineLatest([
-    this.store$.select(searchStore.getSearchType),
-    this.store$.select(sceneStore.getSelectedScene),
-    this.store$.select(filtersStore.getSelectedDatasetId),
-      this.store$.select(sceneStore.getSelectedSarviewsEventProducts)]
-    ).pipe(
-      map(([searchtype, selectedScene, datasetID, selectedEventProducts]) => {
-        switch (searchtype) {
-          case models.SearchType.DATASET:
-            return datasetID === 'AVNIR'
-            || datasetID === 'SENTINEL-1'
-            || datasetID === 'SENTINEL-1 INTERFEROGRAM (BETA)'
-            || datasetID === 'UAVSAR';
-          case models.SearchType.SARVIEWS_EVENTS:
-            return selectedEventProducts?.length > 0;
-          case models.SearchType.LIST:
-            return selectedScene?.dataset === 'ALOS'
-            || selectedScene?.dataset === 'Sentinel-1A'
-            || selectedScene?.dataset === 'Sentinel-1B'
-            || selectedScene?.dataset === 'Sentinel-1 Interferogram (BETA)'
-            || selectedScene?.dataset === 'UAVSAR';
-          case models.SearchType.CUSTOM_PRODUCTS:
-            return true;
-          default:
-            return false;
-
-        }
-    }),
-  );
 
   public setPinnedProducts(pinnedProducts: {[product_id in string]: PinnedProduct}, productLayerGroup: LayerGroup) {
 

--- a/src/app/services/browse-overlay.service.ts
+++ b/src/app/services/browse-overlay.service.ts
@@ -12,13 +12,23 @@ import { Coordinate } from 'ol/coordinate';
 import MultiPolygon from 'ol/geom/MultiPolygon';
 import { PinnedProduct } from './browse-map.service';
 import LayerGroup from 'ol/layer/Group';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import * as models from '@models';
+import * as searchStore from '@store/search';
+import * as sceneStore from '@store/scenes';
+import * as filtersStore from '@store/filters';
+import { Store } from '@ngrx/store';
+import { AppState } from '@store';
 
 @Injectable({
   providedIn: 'root'
 })
 export class BrowseOverlayService {
 
-  constructor(private wktService: WktService) { }
+  constructor(private wktService: WktService,
+    private store$: Store<AppState>) { }
 
   private createImageSource(url: string, extent: Extent) {
     return new Static({
@@ -100,6 +110,36 @@ export class BrowseOverlayService {
 
     return Imagelayer;
   }
+
+  public isBrowseOverlayEnabled$: Observable<boolean> = combineLatest([
+    this.store$.select(searchStore.getSearchType),
+    this.store$.select(sceneStore.getSelectedScene),
+    this.store$.select(filtersStore.getSelectedDatasetId),
+      this.store$.select(sceneStore.getSelectedSarviewsEventProducts)]
+    ).pipe(
+      map(([searchtype, selectedScene, datasetID, selectedEventProducts]) => {
+        switch (searchtype) {
+          case models.SearchType.DATASET:
+            return datasetID === 'AVNIR'
+            || datasetID === 'SENTINEL-1'
+            || datasetID === 'SENTINEL-1 INTERFEROGRAM (BETA)'
+            || datasetID === 'UAVSAR';
+          case models.SearchType.SARVIEWS_EVENTS:
+            return selectedEventProducts?.length > 0;
+          case models.SearchType.LIST:
+            return selectedScene?.dataset === 'ALOS'
+            || selectedScene?.dataset === 'Sentinel-1A'
+            || selectedScene?.dataset === 'Sentinel-1B'
+            || selectedScene?.dataset === 'Sentinel-1 Interferogram (BETA)'
+            || selectedScene?.dataset === 'UAVSAR';
+          case models.SearchType.CUSTOM_PRODUCTS:
+            return true;
+          default:
+            return false;
+
+        }
+      }),
+    );
 
   private fixPolygonAntimeridian(feature: Feature<Geometry>, wkt: string) {
     const isMultiPolygon = wkt.includes('MULTIPOLYGON');

--- a/src/app/services/browse-overlay.service.ts
+++ b/src/app/services/browse-overlay.service.ts
@@ -37,6 +37,7 @@ export class BrowseOverlayService {
         switch (searchtype) {
           case models.SearchType.DATASET:
             return datasetID === 'AVNIR'
+            || datasetID === 'ALOS'
             || datasetID === 'SENTINEL-1'
             || datasetID === 'SENTINEL-1 INTERFEROGRAM (BETA)'
             || datasetID === 'UAVSAR';

--- a/src/app/services/browse-overlay.service.ts
+++ b/src/app/services/browse-overlay.service.ts
@@ -111,6 +111,19 @@ export class BrowseOverlayService {
     return Imagelayer;
   }
 
+  private fixPolygonAntimeridian(feature: Feature<Geometry>, wkt: string) {
+    const isMultiPolygon = wkt.includes('MULTIPOLYGON');
+    let polygonCoordinates: Coordinate[];
+    const geom = feature.getGeometry();
+    if (isMultiPolygon) {
+      polygonCoordinates = (geom as MultiPolygon).getPolygon(0).getCoordinates()[0];
+      (geom as MultiPolygon).setCoordinates([[this.wktService.fixAntimeridianCoordinates(polygonCoordinates)]]);
+    } else {
+      polygonCoordinates = (geom as Polygon).getCoordinates()[0];
+      (geom as Polygon).setCoordinates([this.wktService.fixAntimeridianCoordinates(polygonCoordinates)]);
+    }
+  }
+
   public isBrowseOverlayEnabled$: Observable<boolean> = combineLatest([
     this.store$.select(searchStore.getSearchType),
     this.store$.select(sceneStore.getSelectedScene),
@@ -138,21 +151,8 @@ export class BrowseOverlayService {
             return false;
 
         }
-      }),
-    );
-
-  private fixPolygonAntimeridian(feature: Feature<Geometry>, wkt: string) {
-    const isMultiPolygon = wkt.includes('MULTIPOLYGON');
-    let polygonCoordinates: Coordinate[];
-    const geom = feature.getGeometry();
-    if (isMultiPolygon) {
-      polygonCoordinates = (geom as MultiPolygon).getPolygon(0).getCoordinates()[0];
-      (geom as MultiPolygon).setCoordinates([[this.wktService.fixAntimeridianCoordinates(polygonCoordinates)]]);
-    } else {
-      polygonCoordinates = (geom as Polygon).getCoordinates()[0];
-      (geom as Polygon).setCoordinates([this.wktService.fixAntimeridianCoordinates(polygonCoordinates)]);
-    }
-  }
+    }),
+  );
 
   public setPinnedProducts(pinnedProducts: {[product_id in string]: PinnedProduct}, productLayerGroup: LayerGroup) {
 

--- a/src/app/store/map/map.effect.ts
+++ b/src/app/store/map/map.effect.ts
@@ -81,8 +81,8 @@ export class MapEffects {
     map(([product, _]) => product),
     filter(product => product.browses.length > 0),
     tap((selectedProduct: CMRProduct) => {
-      if(selectedProduct.dataset === 'ALOS') {
-        if(selectedProduct.metadata.productType !== 'RTC_LOW_RES'
+      if (selectedProduct.dataset === 'ALOS') {
+        if (selectedProduct.metadata.productType !== 'RTC_LOW_RES'
           && selectedProduct.metadata.productType !== 'RTC_HI_RES') {
             return;
           }

--- a/src/app/store/map/map.effect.ts
+++ b/src/app/store/map/map.effect.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { SearchType } from '@models';
+import { CMRProduct, SearchType } from '@models';
 
 
 import * as models from '@models';
@@ -54,6 +54,7 @@ export class MapEffects {
     filter(([[_, searchType], dataset]) => {
     if (searchType === SearchType.DATASET) {
       return dataset?.id === 'AVNIR'
+      || dataset?.id === 'ALOS'
       || dataset?.id === 'SENTINEL-1'
       || dataset?.id === 'SENTINEL-1 INTERFEROGRAM (BETA)'
       || dataset?.id === 'UAVSAR';
@@ -79,7 +80,13 @@ export class MapEffects {
     }),
     map(([product, _]) => product),
     filter(product => product.browses.length > 0),
-    tap((selectedProduct) => {
+    tap((selectedProduct: CMRProduct) => {
+      if(selectedProduct.dataset === 'ALOS') {
+        if(selectedProduct.metadata.productType !== 'RTC_LOW_RES'
+          && selectedProduct.metadata.productType !== 'RTC_HI_RES') {
+            return;
+          }
+      }
       if (selectedProduct.browses[0] !== '/assets/no-browse.png') {
         this.mapService.setSelectedBrowse(selectedProduct.browses[0], selectedProduct.metadata.polygon);
       }


### PR DESCRIPTION
- Add "experimental" indicator to download queue's Download All feature
- Use product name instead of input scene name when listing On Demand products in download queue
- Browse image selection for map overlay is now synced with browse image selection in search results center column
  - Browse image selection controls no longer in map toolbar
- More clearly indicate On Demand processing option states
- Map toolbar is now collapsible and no longer draggable
- Event Search products can now be pinned for persistent map overlay directly from their image preview in the center column