### PR TITLE
Bug Fix: Event Search image viewer product download

### DIFF
--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -302,9 +302,8 @@
                     }}
                   </span>
                   <app-download-file-button
-                    [attr.id]="'imgV_' + currentSarviewsCMRProduct.id"
                     [product]="currentSarviewsCMRProduct"
-                    (click)="$event.stopPropagation()"
+                    [url]="currentSarviewsCMRProduct.downloadUrl"
                   >
                   </app-download-file-button>
                 </button>

--- a/src/app/components/shared/download-file-button/download-file-button.component.ts
+++ b/src/app/components/shared/download-file-button/download-file-button.component.ts
@@ -22,11 +22,11 @@ export class DownloadFileButtonComponent implements OnInit, AfterViewInit {
   @Input() href: string;
   @Input() disabled: boolean;
   @Input() useNewDownload: boolean;
+  @Input() url: string;
   @Output()
   productDownloaded: EventEmitter<CMRProduct> = new EventEmitter<CMRProduct>();
   @Output() downloadCancelled: EventEmitter<CMRProduct> = new EventEmitter<CMRProduct>();
   public dFile: DownloadStatus;
-  public url: string;
   public fileName: string = null;
 
   public observable$: Observable<DownloadStatus>;


### PR DESCRIPTION
subsequent products downloaded from the image viewer file button menu on event search no longer re-download the first downloaded product.