### PR TITLE
Bug Fix: Event Search Product Download Status

### DIFF
--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -285,7 +285,7 @@
               <button
                 class="file-button-download"
                 [matMenuTriggerFor]="event_action_menu"
-                [matMenuTriggerData]="{prod: currentSarviewsCMRProduct}"
+                [matMenuTriggerData]="{eventProduct: currentSarviewsCMRProduct}"
                 *ngIf="!!currentSarviewsProduct"
                 mat-list-item
               >
@@ -298,7 +298,7 @@
                   mat-menu-item
                   *ngIf="!!currentSarviewsProduct"
                 >
-                <ng-template let-prod="prod" matMenuContent>
+                <ng-template let-eventProduct="eventProduct" matMenuContent>
                   <span *ngIf="currentSarviewsProduct.files.product_size !== 0">
                     {{
                       currentSarviewsProduct.files.product_size.toString()
@@ -306,8 +306,9 @@
                     }}
                   </span>
                   <app-download-file-button
-                    [product]="prod"
-                    [url]="prod.downloadUrl"
+                  [attr.id]="'imgV_' + eventProduct.id"
+                  [product]="eventProduct"
+                  (click)="$event.stopPropagation()"
                   >
                   </app-download-file-button>
                 </ng-template>

--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -285,16 +285,20 @@
               <button
                 class="file-button-download"
                 [matMenuTriggerFor]="event_action_menu"
+                [matMenuTriggerData]="{prod: currentSarviewsCMRProduct}"
                 *ngIf="!!currentSarviewsProduct"
                 mat-list-item
               >
                 <b>• {{ currentSarviewsProduct.job_type.replace('_', ' ') }}</b>
               </button>
               <mat-menu #event_action_menu xPosition="before">
+
                 <button
+
                   mat-menu-item
                   *ngIf="!!currentSarviewsProduct"
                 >
+                <ng-template let-prod="prod" matMenuContent>
                   <span *ngIf="currentSarviewsProduct.files.product_size !== 0">
                     {{
                       currentSarviewsProduct.files.product_size.toString()
@@ -302,10 +306,11 @@
                     }}
                   </span>
                   <app-download-file-button
-                    [product]="currentSarviewsCMRProduct"
-                    [url]="currentSarviewsCMRProduct.downloadUrl"
+                    [product]="prod"
+                    [url]="prod.downloadUrl"
                   >
                   </app-download-file-button>
+                </ng-template>
                 </button>
                 <button
                   (click)="onToggleQueueEventProduct(currentSarviewsProduct)"

--- a/src/app/components/shared/download-file-button/download-file-button.component.ts
+++ b/src/app/components/shared/download-file-button/download-file-button.component.ts
@@ -22,13 +22,12 @@ export class DownloadFileButtonComponent implements OnInit, AfterViewInit {
   @Input() href: string;
   @Input() disabled: boolean;
   @Input() useNewDownload: boolean;
-  @Input() url: string;
-  @Input() fileName: string = null;
   @Output()
   productDownloaded: EventEmitter<CMRProduct> = new EventEmitter<CMRProduct>();
   @Output() downloadCancelled: EventEmitter<CMRProduct> = new EventEmitter<CMRProduct>();
   public dFile: DownloadStatus;
-
+  public url: string;
+  public fileName: string = null;
 
   public observable$: Observable<DownloadStatus>;
   public subscription: Subscription;

--- a/src/app/components/shared/download-file-button/download-file-button.component.ts
+++ b/src/app/components/shared/download-file-button/download-file-button.component.ts
@@ -23,11 +23,12 @@ export class DownloadFileButtonComponent implements OnInit, AfterViewInit {
   @Input() disabled: boolean;
   @Input() useNewDownload: boolean;
   @Input() url: string;
+  @Input() fileName: string = null;
   @Output()
   productDownloaded: EventEmitter<CMRProduct> = new EventEmitter<CMRProduct>();
   @Output() downloadCancelled: EventEmitter<CMRProduct> = new EventEmitter<CMRProduct>();
   public dFile: DownloadStatus;
-  public fileName: string = null;
+
 
   public observable$: Observable<DownloadStatus>;
   public subscription: Subscription;


### PR DESCRIPTION
- The image dialog file button on event search now properly displays it's download status
- The button menu's content is now lazy loaded with event data (button is initialized whenever user selects a new product on event search in the image dialog window)