### PR TITLE
DS-4216 vertex docs in modal

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,8 +37,6 @@ import * as services from '@services';
 
 import { NgcCookieConsentModule, NgcCookieConsentConfig } from 'ngx-cookieconsent';
 import { getSaver, SAVER } from '@services/saver.provider';
-// import { OnlynumberDirective } from './directives/onlynumber.directive';
-// import { FileDownloadDirective } from './directives/file-download.directive';
 
 // info about cookie consent module: https://tinesoft.github.io/ngx-cookieconsent/home
 const cookieConfig: NgcCookieConsentConfig = {
@@ -77,9 +75,7 @@ export const routes = [
 
 @NgModule({
   declarations: [
-    AppComponent
-    // OnlynumberDirective,
-    // FileDownloadDirective,
+    AppComponent,
   ],
   imports: [
     BrowserModule,
@@ -143,7 +139,7 @@ export const routes = [
     // { provide: Window, useValue: window },
   ],
   bootstrap: [AppComponent],
-  exports: [ MatTableModule
+  exports: [MatTableModule,
   ]
 })
 export class AppModule {}

--- a/src/app/components/filters-dropdown/baseline-filters/baseline-filters.component.html
+++ b/src/app/components/filters-dropdown/baseline-filters/baseline-filters.component.html
@@ -42,8 +42,10 @@
     </app-copy-to-clipboard>
     </div>
     <div>
-      <a href="https://docs.asf.alaska.edu/vertex/baseline/" target="_blank">What is Baseline?</a>
-
+      <app-docs-modal class="info-icon"
+                      url="https://docs.asf.alaska.edu/vertex/baseline/"
+                      text="What is Baseline?">
+      </app-docs-modal>
     </div>
   </mat-expansion-panel>
 

--- a/src/app/components/filters-dropdown/baseline-filters/baseline-filters.module.ts
+++ b/src/app/components/filters-dropdown/baseline-filters/baseline-filters.module.ts
@@ -10,21 +10,23 @@ import { MasterSceneSelectorModule } from '@components/shared/selectors/master-s
 import { SearchTypeSelectorModule } from '@components/shared/selectors/search-type-selector';
 import { BaselineSlidersModule } from './baseline-sliders';
 import { CopyToClipboardModule } from '@components/shared/copy-to-clipboard';
+import {DocsModalModule} from '@components/shared/docs-modal';
 
 
 @NgModule({
   declarations: [BaselineFiltersComponent],
-  imports: [
-    CommonModule,
-    MatExpansionModule,
-    MatSharedModule,
-    SeasonSelectorModule,
-    MasterSceneSelectorModule,
-    DateSelectorModule,
-    SearchTypeSelectorModule,
-    BaselineSlidersModule,
-    CopyToClipboardModule
-  ],
+    imports: [
+        CommonModule,
+        MatExpansionModule,
+        MatSharedModule,
+        SeasonSelectorModule,
+        MasterSceneSelectorModule,
+        DateSelectorModule,
+        SearchTypeSelectorModule,
+        BaselineSlidersModule,
+        CopyToClipboardModule,
+        DocsModalModule
+    ],
   exports: [
     BaselineFiltersComponent
   ]

--- a/src/app/components/filters-dropdown/dataset-filters/dataset-filters.component.html
+++ b/src/app/components/filters-dropdown/dataset-filters/dataset-filters.component.html
@@ -30,8 +30,12 @@
     [class.raised-section]="isSelected(panels.AOI)">
 
     <mat-expansion-panel-header [collapsedHeight]="customCollapsedHeight" [expandedHeight]="customExpandedHeight">
-      <mat-panel-title>
+      <mat-panel-title style="align-items: center;">
         Area of Interest Options
+        <app-docs-modal class="info-icon"
+                        url="https://docs.asf.alaska.edu/vertex/manual/#area-of-interest-options">
+        </app-docs-modal>
+
       </mat-panel-title>
     </mat-expansion-panel-header>
 
@@ -68,7 +72,9 @@
     <mat-expansion-panel-header [collapsedHeight]="customCollapsedHeight" [expandedHeight]="customExpandedHeight">
       <mat-panel-title style="align-items: center;">
         Additional Filters
-        <mat-icon (click)="onOpenHelp('https://docs.asf.alaska.edu/vertex/manual/#additional-filters')" class="clickable" style="margin-left: 10px;">info</mat-icon>
+        <app-docs-modal class="info-icon"
+                        url="https://docs.asf.alaska.edu/vertex/manual/#additional-filters">
+        </app-docs-modal>
       </mat-panel-title>
     </mat-expansion-panel-header>
 
@@ -85,7 +91,9 @@
     <mat-expansion-panel-header [collapsedHeight]="customCollapsedHeight" [expandedHeight]="customExpandedHeight">
       <mat-panel-title style="align-items: center;">
         Path and Frame Filters
-        <mat-icon (click)="onOpenHelp('https://docs.asf.alaska.edu/vertex/manual/#path-and-frame-filters')" class="clickable" style="margin-left: 10px;">info</mat-icon>
+        <app-docs-modal class="info-icon"
+                        url="https://docs.asf.alaska.edu/vertex/manual/#path-and-frame-filters">
+        </app-docs-modal>
       </mat-panel-title>
     </mat-expansion-panel-header>
 

--- a/src/app/components/filters-dropdown/dataset-filters/dataset-filters.component.html
+++ b/src/app/components/filters-dropdown/dataset-filters/dataset-filters.component.html
@@ -47,7 +47,9 @@
     <mat-expansion-panel-header [collapsedHeight]="customCollapsedHeight" [expandedHeight]="customExpandedHeight">
       <mat-panel-title style="align-items: center;">
         Date Filters
-        <mat-icon (click)="onOpenHelp('https://docs.asf.alaska.edu/vertex/manual/#date-filters')" class="clickable" style="margin-left: 10px;">info</mat-icon>
+        <app-docs-modal class="info-icon"
+          url="https://docs.asf.alaska.edu/vertex/manual/#date-filters">
+        </app-docs-modal>
       </mat-panel-title>
     </mat-expansion-panel-header>
 

--- a/src/app/components/filters-dropdown/dataset-filters/dataset-filters.component.scss
+++ b/src/app/components/filters-dropdown/dataset-filters/dataset-filters.component.scss
@@ -8,3 +8,8 @@
 .selector-card-spacing {
   margin-top: 20px;
 }
+
+.info-icon {
+  margin-left: 10px;
+  margin-top: 4px;
+}

--- a/src/app/components/filters-dropdown/dataset-filters/dataset-filters.module.ts
+++ b/src/app/components/filters-dropdown/dataset-filters/dataset-filters.module.ts
@@ -16,6 +16,7 @@ import { DatasetFiltersComponent } from './dataset-filters.component';
 import { DateSelectorModule } from '@components/shared/selectors/date-selector';
 import { DatasetSelectorModule } from '@components/shared/selectors/dataset-selector';
 import { AoiOptionsModule } from '@components/shared/aoi-options';
+import { DocsModalModule } from '@components/shared/docs-modal';
 
 @NgModule({
   declarations: [
@@ -28,7 +29,7 @@ import { AoiOptionsModule } from '@components/shared/aoi-options';
     MatSelectModule,
     MatExpansionModule,
     MatSharedModule,
-
+    DocsModalModule,
     MissionSelectorModule,
     PathSelectorModule,
     OtherSelectorModule,

--- a/src/app/components/filters-dropdown/sbas-filters/sbas-filters.component.html
+++ b/src/app/components/filters-dropdown/sbas-filters/sbas-filters.component.html
@@ -50,14 +50,6 @@
     </div>
   </mat-expansion-panel>
 
-
-
-
-
-
-
-
-
   <mat-expansion-panel [expanded]="defaultPanelOpenState" [disabled]="panelIsDisabled"
     (click)="selectPanel(panels.DATE)"
     *ngIf="areResultsLoaded"

--- a/src/app/components/filters-dropdown/sbas-filters/sbas-filters.component.html
+++ b/src/app/components/filters-dropdown/sbas-filters/sbas-filters.component.html
@@ -43,7 +43,10 @@
     </app-copy-to-clipboard>
     </div>
     <div>
-      <a href="https://docs.asf.alaska.edu/vertex/sbas/" target="_blank">What is SBAS?</a>
+      <app-docs-modal class="info-icon"
+                      url="https://docs.asf.alaska.edu/vertex/sbas/"
+                      text="What is SBAS?">
+      </app-docs-modal>
     </div>
   </mat-expansion-panel>
 

--- a/src/app/components/filters-dropdown/sbas-filters/sbas-filters.module.ts
+++ b/src/app/components/filters-dropdown/sbas-filters/sbas-filters.module.ts
@@ -11,6 +11,7 @@ import { MasterSceneSelectorModule } from '@components/shared/selectors/master-s
 import { SearchTypeSelectorModule } from '@components/shared/selectors/search-type-selector';
 import { ResultsMenuModule } from '@components/results-menu';
 import { CopyToClipboardModule } from '@components/shared/copy-to-clipboard';
+import {DocsModalModule} from '@components/shared/docs-modal';
 
 
 @NgModule({
@@ -25,7 +26,8 @@ import { CopyToClipboardModule } from '@components/shared/copy-to-clipboard';
         MasterSceneSelectorModule,
         SearchTypeSelectorModule,
         ResultsMenuModule,
-        CopyToClipboardModule
+        CopyToClipboardModule,
+        DocsModalModule
     ],
   exports: [
     SbasFiltersComponent

--- a/src/app/components/help/help.module.ts
+++ b/src/app/components/help/help.module.ts
@@ -25,6 +25,7 @@ import { HelpDownloadQueueComponent } from './help-pages/help-download-queue/hel
 import { HelpExportOptionsComponent } from './help-pages/help-export-options/help-export-options.component';
 import { HelpOnDemandComponent } from './help-pages/help-on-demand/help-on-demand.component';
 import {MatInputModule} from '@angular/material/input';
+import {DocsModalModule} from '@components/shared/docs-modal';
 
 
 @NgModule({
@@ -52,7 +53,8 @@ import {MatInputModule} from '@angular/material/input';
         MatSharedModule,
         MatTableModule,
         MatSortModule,
-        MatInputModule
+        MatInputModule,
+        DocsModalModule
     ],
   exports: [
     HelpComponent

--- a/src/app/components/shared/docs-modal/docs-modal-iframe.html
+++ b/src/app/components/shared/docs-modal/docs-modal-iframe.html
@@ -1,0 +1,11 @@
+<!--<h2 mat-dialog-title>Vertex Help Manual</h2>-->
+<hr class="content-hr">
+<mat-dialog-content class="mat-typography content-container">
+    <iframe [src]="data.safeUrl" class="iframe-style"></iframe>
+</mat-dialog-content>
+<hr class="content-hr">
+<mat-dialog-actions align="end">
+  <button mat-raised-button mat-dialog-close cdkFocusInitial>Cancel</button>
+<!--  <button mat-raised-button [mat-dialog-close]="true" (click)="openDoc()">Open Manual</button>-->
+  <button mat-raised-button mat-dialog-close (click)="openDoc()">Open Manual</button>
+</mat-dialog-actions>

--- a/src/app/components/shared/docs-modal/docs-modal-iframe.scss
+++ b/src/app/components/shared/docs-modal/docs-modal-iframe.scss
@@ -18,7 +18,7 @@
 }
 
 .mat-dialog-actions {
-  padding: 16px 0 8px 0;
+  padding: 16px 0 8px;
 }
 
 .content-hr {

--- a/src/app/components/shared/docs-modal/docs-modal-iframe.scss
+++ b/src/app/components/shared/docs-modal/docs-modal-iframe.scss
@@ -1,0 +1,27 @@
+.content-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.iframe-style {
+  flex-grow: 1;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mat-dialog-content {
+  max-height: calc(100% - 80px);
+}
+
+.mat-dialog-actions {
+  padding: 16px 0 8px 0;
+}
+
+.content-hr {
+  padding: 0;
+  margin: 0;
+}

--- a/src/app/components/shared/docs-modal/docs-modal.component.html
+++ b/src/app/components/shared/docs-modal/docs-modal.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="text; else elseBlock">
-  <a (click)="showDoc()" class="link-pointer">
+  <a (click)="showDoc()" class="link-pointer text-link">
     {{ text }}
   </a>
 </div>

--- a/src/app/components/shared/docs-modal/docs-modal.component.html
+++ b/src/app/components/shared/docs-modal/docs-modal.component.html
@@ -1,0 +1,10 @@
+<div *ngIf="text; else elseBlock">
+  <a (click)="showDoc()" class="link-pointer">
+    {{ text }}
+  </a>
+</div>
+<ng-template #elseBlock>
+  <a (click)="showDoc()" class="link-pointer">
+    <mat-icon>info</mat-icon>
+  </a>
+</ng-template>

--- a/src/app/components/shared/docs-modal/docs-modal.component.scss
+++ b/src/app/components/shared/docs-modal/docs-modal.component.scss
@@ -1,0 +1,5 @@
+@import "asf-help";
+
+.link-pointer {
+  cursor: pointer;
+}

--- a/src/app/components/shared/docs-modal/docs-modal.component.scss
+++ b/src/app/components/shared/docs-modal/docs-modal.component.scss
@@ -3,3 +3,8 @@
 .link-pointer {
   cursor: pointer;
 }
+
+.text-link {
+  color: -webkit-link;
+  text-decoration: underline;
+}

--- a/src/app/components/shared/docs-modal/docs-modal.component.spec.ts
+++ b/src/app/components/shared/docs-modal/docs-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DocsModalComponent } from './docs-modal.component';
+
+describe('DocsModalComponent', () => {
+  let component: DocsModalComponent;
+  let fixture: ComponentFixture<DocsModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DocsModalComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DocsModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/shared/docs-modal/docs-modal.component.ts
+++ b/src/app/components/shared/docs-modal/docs-modal.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input, OnInit, Inject } from '@angular/core';
+import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DomSanitizer } from '@angular/platform-browser';
+
+export interface DialogData {
+  rawUrl: string;
+  safeUrl: any;
+}
+
+@Component({
+  selector: 'app-docs-modal',
+  templateUrl: './docs-modal.component.html',
+  styleUrls: ['./docs-modal.component.scss']
+})
+export class DocsModalComponent implements OnInit {
+  @Input() url: string;
+  @Input() text: string;
+
+  // public docURL = 'https://docs.asf.alaska.edu/vertex/manual/#date-filters';
+  public docURL: string;
+  public safeDocURL: any;
+
+  constructor(public dialog: MatDialog,
+              private _sanitizer: DomSanitizer) {}
+
+  ngOnInit(): void {
+    this.docURL = this.url;
+    this.safeDocURL = this._sanitizer.bypassSecurityTrustResourceUrl(this.docURL);
+  }
+
+  public showDoc() {
+    const dialogRef = this.dialog.open(DocsModalIframeComponent, {
+      width: '80vw', // sets width of dialog
+      height: '80vh', // sets width of dialog
+      maxWidth: '100vw', // overrides default width of dialog
+      maxHeight: '100vh', // overrides default height of dialog
+      data: {
+        rawUrl: this.docURL,
+        safeUrl: this.safeDocURL,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      console.log(`Dialog result: ${result}`);
+    });
+  }
+}
+
+@Component({
+  selector: 'app-docs-modal-iframe',
+  templateUrl: 'docs-modal-iframe.html',
+  styleUrls: ['docs-modal-iframe.scss']
+})
+export class DocsModalIframeComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) {}
+  public openDoc() {
+    window.open(this.data.rawUrl, '_blank');
+  }
+}

--- a/src/app/components/shared/docs-modal/docs-modal.component.ts
+++ b/src/app/components/shared/docs-modal/docs-modal.component.ts
@@ -36,7 +36,6 @@ export class DocsModalComponent implements OnInit {
   @Input() url: string;
   @Input() text: string;
 
-  // public docURL = 'https://docs.asf.alaska.edu/vertex/manual/#date-filters';
   public docURL: string;
   public safeDocURL: any;
 

--- a/src/app/components/shared/docs-modal/docs-modal.component.ts
+++ b/src/app/components/shared/docs-modal/docs-modal.component.ts
@@ -1,3 +1,23 @@
+// This component presents a info-icon or text link that opens a modal containing an iFrame displaying
+// ASF's documentation (mkDocs) at a specified page and anchor.
+//
+// * Using the component without setting values results in info-icon that opens a modal of the documentation home page.
+// * Setting the "url" value will result in the specified URL being opened.
+// * Setting a value for "text" will result in the specified text being displayed in place of the info-icon.
+// * You can apply a class to the component to change the formatting of the info-icon or text.
+//
+// USAGE EXAMPLES:
+//
+//   <app-docs-modal></app-docs-modal>
+//
+//   <app-docs-modal url="https://docs.asf.alaska.edu/vertex/manual/#date-filters">
+//   </app-docs-modal>
+//
+//    <app-docs-modal class="info-icon"
+//      text="Documentation"
+//      url="https://docs.asf.alaska.edu/vertex/manual/#date-filters">
+//    </app-docs-modal>
+
 import { Component, Input, OnInit, Inject } from '@angular/core';
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -24,7 +44,7 @@ export class DocsModalComponent implements OnInit {
               private _sanitizer: DomSanitizer) {}
 
   ngOnInit(): void {
-    this.docURL = this.url;
+    this.docURL = ( this.url ) ? this.url : 'https://docs.asf.alaska.edu';
     this.safeDocURL = this._sanitizer.bypassSecurityTrustResourceUrl(this.docURL);
   }
 

--- a/src/app/components/shared/docs-modal/docs-modal.module.ts
+++ b/src/app/components/shared/docs-modal/docs-modal.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { MatSharedModule } from '@shared';
+import { DocsModalComponent, DocsModalIframeComponent } from './docs-modal.component';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialogModule } from '@angular/material/dialog';
+
+
+@NgModule({
+  declarations: [
+    DocsModalComponent,
+    DocsModalIframeComponent,
+  ],
+  imports: [
+    CommonModule,
+    MatSharedModule,
+    MatIconModule,
+    MatDialogModule,
+  ],
+  exports: [
+    DocsModalComponent,
+    DocsModalIframeComponent,
+  ]
+})
+export class DocsModalModule { }

--- a/src/app/components/shared/docs-modal/index.ts
+++ b/src/app/components/shared/docs-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './docs-modal.module';


### PR DESCRIPTION
Created a component for embedding docs into Vertex and updated all of the search info-icon links to use it.

// This component presents a info-icon or text link that opens a modal containing an iFrame displaying
// ASF's documentation (mkDocs) at a specified page and anchor.
//
// * Using the component without setting values results in info-icon that opens a modal of the documentation home page.
// * Setting the "url" value will result in the specified URL being opened.
// * Setting a value for "text" will result in the specified text being displayed in place of the info-icon.
// * You can apply a class to the component to change the formatting of the info-icon or text.
//
// USAGE EXAMPLES:
//
//   <app-docs-modal></app-docs-modal>
//
//   <app-docs-modal url="https://docs.asf.alaska.edu/vertex/manual/#date-filters">
//   </app-docs-modal>
//
//    <app-docs-modal class="info-icon"
//      text="Documentation"
//      url="https://docs.asf.alaska.edu/vertex/manual/#date-filters">
//    </app-docs-modal>
