### PR TITLE
Event Search Zoom (DS-4235)

### DIFF
--- a/src/app/components/header/info-bar/info-bar.component.html
+++ b/src/app/components/header/info-bar/info-bar.component.html
@@ -4,12 +4,6 @@
      class="info-bar">
 
   <div class="first-info">
-    <span *ngIf="(searchType$ | async) === searchTypes.SARVIEWS_EVENTS" class="sarviews">
-      Events provided by
-      <a href="https://sarviews-hazards.alaska.edu/" target="_blank" style="color: unset;">
-        SARVIEWS
-      </a>
-    </span>
     <span *ngIf="(searchType$ | async) === searchTypes.SARVIEWS_EVENTS && !!eventProductTypes">
       <b>Product Types:</b> {{eventProductTypes}}
     </span>

--- a/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.html
+++ b/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.html
@@ -34,7 +34,7 @@
   </div>
     <ng-container>
       <div class="scene-controls" [ngClass]="{'mobile-size': breakpoint <= breakpoints.SMALL}">
-        <mat-icon (click)="onZoomTo(); $event.stopPropagation();" class="ml-2" matTooltip="Zoom to event">
+        <mat-icon (click)="onZoomTo($event)" class="ml-2" matTooltip="Zoom to event">
           settings_overscan
         </mat-icon>
       </div>

--- a/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.html
+++ b/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.html
@@ -34,7 +34,7 @@
   </div>
     <ng-container>
       <div class="scene-controls" [ngClass]="{'mobile-size': breakpoint <= breakpoints.SMALL}">
-        <mat-icon (click)="onZoomTo()" class="ml-2" matTooltip="Zoom to event">
+        <mat-icon (click)="onZoomTo(); $event.stopPropagation();" class="ml-2" matTooltip="Zoom to event">
           settings_overscan
         </mat-icon>
       </div>

--- a/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.ts
+++ b/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.ts
@@ -41,7 +41,7 @@ export class SarviewsEventComponent implements OnInit {
   }
 
   public onSetSelected() {
-    if(!this.selected) {
+    if (!this.selected) {
       this.mapService.selectedSarviewEvent$.next(this.event.event_id);
       this.store$.dispatch(new sceneStore.SetSelectedSarviewsEvent(this.event.event_id));
     }
@@ -88,7 +88,7 @@ export class SarviewsEventComponent implements OnInit {
   public onZoomTo($event: Event) {
     this.mapService.zoomToEvent(this.event);
 
-    if(this.selected) {
+    if (this.selected) {
       $event.stopPropagation();
     }
   }

--- a/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.ts
+++ b/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.ts
@@ -41,8 +41,10 @@ export class SarviewsEventComponent implements OnInit {
   }
 
   public onSetSelected() {
-    this.mapService.selectedSarviewEvent$.next(this.event.event_id);
-    this.store$.dispatch(new sceneStore.SetSelectedSarviewsEvent(this.event.event_id));
+    if(!this.selected) {
+      this.mapService.selectedSarviewEvent$.next(this.event.event_id);
+      this.store$.dispatch(new sceneStore.SetSelectedSarviewsEvent(this.event.event_id));
+    }
   }
 
   public eventIDDisplay(): string {
@@ -83,8 +85,12 @@ export class SarviewsEventComponent implements OnInit {
   }
 
   // "Earthquake_inactive.svg
-  public onZoomTo() {
+  public onZoomTo($event: Event) {
     this.mapService.zoomToEvent(this.event);
+
+    if(this.selected) {
+      $event.stopPropagation();
+    }
   }
 
 }

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -273,7 +273,7 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
         filter(selected => !!selected.selectedEvent),
         tap(selected => {
           this.mapService.zoomToEvent(selected.selectedEvent);
-          this.selectedEvent = selected.selectedEvent.event_id
+          this.selectedEvent = selected.selectedEvent.event_id;
         }),
         first(),
         map(selected => {

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -271,8 +271,10 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
     map(([events, selected]) => ({selectedEvent: selected, events})),
         delay(400),
         filter(selected => !!selected.selectedEvent),
-        tap(selected => this.mapService.zoomToEvent(selected.selectedEvent)),
-        tap(selected => this.selectedEvent = selected.selectedEvent.event_id),
+        tap(selected => {
+          this.mapService.zoomToEvent(selected.selectedEvent);
+          this.selectedEvent = selected.selectedEvent.event_id
+        }),
         first(),
         map(selected => {
           const sceneIdx = selected.events.findIndex(event => event.event_id === selected.selectedEvent.event_id);

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -3,7 +3,7 @@ import {
 } from '@angular/core';
 
 import { combineLatest, Observable } from 'rxjs';
-import { tap, withLatestFrom, filter, map, delay, debounceTime, take } from 'rxjs/operators';
+import { tap, withLatestFrom, filter, map, delay, debounceTime, first } from 'rxjs/operators';
 import { SubSink } from 'subsink';
 
 import { Store } from '@ngrx/store';
@@ -271,8 +271,9 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
     map(([events, selected]) => ({selectedEvent: selected, events})),
         delay(400),
         filter(selected => !!selected.selectedEvent),
+        tap(selected => this.mapService.zoomToEvent(selected.selectedEvent)),
         tap(selected => this.selectedEvent = selected.selectedEvent.event_id),
-        take(1),
+        first(),
         map(selected => {
           const sceneIdx = selected.events.findIndex(event => event.event_id === selected.selectedEvent.event_id);
           return Math.max(0, sceneIdx - 1);

--- a/src/app/services/map/map.service.ts
+++ b/src/app/services/map/map.service.ts
@@ -382,7 +382,7 @@ export class MapService {
     );
     this.wktService.fixPolygonAntimeridian(feature, targetEvent.wkt);
 
-    this.map.getView().fit(feature.getGeometry().getSimplifiedGeometry(0) as SimpleGeometry,{
+    this.map.getView().fit(feature.getGeometry().getSimplifiedGeometry(0) as SimpleGeometry, {
       maxZoom: 7,
       size: this.map.getSize(),
       padding: [0, 0, 500, 0],

--- a/src/app/services/map/map.service.ts
+++ b/src/app/services/map/map.service.ts
@@ -40,6 +40,7 @@ import lineIntersect from '@turf/line-intersect';
 import Polygon from 'ol/geom/Polygon';
 import LineString from 'ol/geom/LineString';
 import TileLayer from 'ol/layer/Tile';
+import SimpleGeometry from 'ol/geom/SimpleGeometry';
 
 @Injectable({
   providedIn: 'root'
@@ -379,10 +380,14 @@ export class MapService {
       targetEvent.wkt,
       this.epsg()
     );
-
     this.wktService.fixPolygonAntimeridian(feature, targetEvent.wkt);
 
-    this.zoomToFeature(feature);
+    this.map.getView().fit(feature.getGeometry().getSimplifiedGeometry(0) as SimpleGeometry,{
+      maxZoom: 7,
+      size: this.map.getSize(),
+      padding: [0, 0, 500, 0],
+      duration: 750,
+    });
   }
 
   public zoomToFeature(feature: Feature<Geometry>): void {


### PR DESCRIPTION
Changes to Event Search:
- View pans to selected event on first load/switch to Event Search type, events list scrolls to selected event index as well
- Clicking on currently selected event from list no longer clears pinned products
- Clicking on zoom-to-event button of selected event no longer clears pinned products
- Zoom-to-event buttons has less aggressive zooming, providing better initial view of an event and it's products
- Removes "Events Provided by SARVIEWS'" from filters header