### PR TITLE
New scene auto-selected if previously selected raw scene is hidden

### DIFF
--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { SubSink } from 'subsink';
-import { map, filter, tap, withLatestFrom } from 'rxjs/operators';
+import { map, filter, tap, withLatestFrom, distinctUntilChanged } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
 import { AppState } from '@store';
@@ -113,6 +113,7 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
     );
 
     const scene$ = this.store$.select(scenesStore.getSelectedScene).pipe(
+      distinctUntilChanged((previous, current) => previous?.id === current?.id),
       tap(_ => this.isImageLoading = true)
     );
 

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -3,7 +3,7 @@ import {
 } from '@angular/core';
 
 import { combineLatest, Observable } from 'rxjs';
-import { tap, withLatestFrom, filter, map, delay, debounceTime, first } from 'rxjs/operators';
+import { tap, withLatestFrom, filter, map, delay, debounceTime, first, distinctUntilChanged } from 'rxjs/operators';
 import { SubSink } from 'subsink';
 
 import { Store } from '@ngrx/store';
@@ -17,7 +17,6 @@ import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import * as services from '@services';
 import * as models from '@models';
 import { CMRProduct, QueuedHyp3Job, SarviewsEvent } from '@models';
-import { SetSelectedScene } from '@store/scenes';
 
 @Component({
   selector: 'app-scenes-list',
@@ -142,14 +141,10 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
     );
 
     this.subs.add(
-      sortedScenes$.pipe(debounceTime(250)).subscribe(
-        scenes => {
-          this.scenes = scenes;
-
-          if (!this.scenes.map(scene => scene.id).includes(this.selected)) {
-            this.store$.dispatch(new SetSelectedScene(this.scenes[0].id))
-          }
-        }
+      sortedScenes$.pipe(debounceTime(250)).pipe(
+        distinctUntilChanged(),
+      ).subscribe(
+        scenes => this.scenes = scenes
       )
     );
 

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -16,7 +16,8 @@ import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 
 import * as services from '@services';
 import * as models from '@models';
-import { QueuedHyp3Job, SarviewsEvent } from '@models';
+import { CMRProduct, QueuedHyp3Job, SarviewsEvent } from '@models';
+import { SetSelectedScene } from '@store/scenes';
 
 @Component({
   selector: 'app-scenes-list',
@@ -28,7 +29,7 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
   @ViewChild(CdkVirtualScrollViewport, { static: true }) scroll: CdkVirtualScrollViewport;
   @Input() resize$: Observable<void>;
 
-  public scenes;
+  public scenes: CMRProduct[];
   public pairs;
   public jobs;
   public sarviewsEvents: SarviewsEvent[];
@@ -144,6 +145,10 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
       sortedScenes$.pipe(debounceTime(250)).subscribe(
         scenes => {
           this.scenes = scenes;
+
+          if (!this.scenes.map(scene => scene.id).includes(this.selected)) {
+            this.store$.dispatch(new SetSelectedScene(this.scenes[0].id))
+          }
         }
       )
     );

--- a/src/app/store/scenes/scenes.effect.ts
+++ b/src/app/store/scenes/scenes.effect.ts
@@ -128,10 +128,10 @@ export class ScenesEffects {
       ),
     map(([[_, scenes], selected]) => {
       if (!scenes.map(scene => scene.id).includes(selected.id)) {
-        this.store$.dispatch(new SetSelectedScene(scenes[0].id))
+        this.store$.dispatch(new SetSelectedScene(scenes[0].id));
       }
     })
-  ), {dispatch: false})
+  ), {dispatch: false});
 
   private showUnzipApiLoadError(product: CMRProduct): void {
     this.notificationService.error(

--- a/src/app/store/scenes/scenes.effect.ts
+++ b/src/app/store/scenes/scenes.effect.ts
@@ -15,6 +15,7 @@ import { allScenesFrom, getSelectedScene, SetSarviewsEventProducts, SetSelectedS
 import { SarviewsEventsService, ScenesService } from '@services';
 import { AppState } from '@store/app.reducer';
 import { Store } from '@ngrx/store';
+import { HideS1RawData, UIActionType } from '@store/ui';
 
 @Injectable()
 export class ScenesEffects {
@@ -116,6 +117,21 @@ export class ScenesEffects {
       return new SetSelectedScene(current_selected);
     })
   ));
+
+  public onHideRawData = createEffect(() => this.actions$.pipe(
+    ofType<HideS1RawData>(UIActionType.HIDE_S1_RAW_DATA),
+    debounceTime(1000),
+    withLatestFrom(
+        this.sceneService.scenes$()),
+        withLatestFrom(
+        this.store$.select(getSelectedScene)
+      ),
+    map(([[_, scenes], selected]) => {
+      if (!scenes.map(scene => scene.id).includes(selected.id)) {
+        this.store$.dispatch(new SetSelectedScene(scenes[0].id))
+      }
+    })
+  ), {dispatch: false})
 
   private showUnzipApiLoadError(product: CMRProduct): void {
     this.notificationService.error(


### PR DESCRIPTION
- If a user hides raw data and a raw scene had been selected, the first available scene in the filtered results is selected
- Raw data scene isn't the first scene selected if it's hidden when results are initially loaded 
- Scene Detail browse image viewer no longer disappears on initial load after results are loaded