### PR TITLE
if an event's description is missing it's event type and date is displayed instead

### DIFF
--- a/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
+++ b/src/app/components/results-menu/scene-detail/image-dialog/image-dialog.component.html
@@ -55,7 +55,8 @@
     >
       <div fxFlex="auto">
         <h3 class="mp0">
-          <span
+          <ng-template [ngIf]="!!event.description" [ngIfElse]="NO_DESCRIPTION">
+            <span
             [ngClass]="{
               'mp0-ellipsis-mobile': breakpoint <= breakpoints.SMALL,
               'mp0-ellipsis': breakpoint > breakpoints.SMALL
@@ -63,6 +64,17 @@
           >
             {{ event.description }}
           </span>
+        </ng-template>
+          <ng-template #NO_DESCRIPTION>
+            <span
+            [ngClass]="{
+              'mp0-ellipsis-mobile': breakpoint <= breakpoints.SMALL,
+              'mp0-ellipsis': breakpoint > breakpoints.SMALL
+            }"
+          >
+              {{event.event_type[0].toLocaleUpperCase()}}{{event.event_type.slice(1)}} Event: {{event.processing_timeframe.start | shortDate}}
+            </span>
+          </ng-template>
         </h3>
         <span class="faint-text">
           <a

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.html
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.html
@@ -6,10 +6,21 @@
   <div *ngIf="sarviewEvent">
     <mat-card-header>
       <mat-card-title class="detail-card-header">
-        <span>{{
-          sarviewEvent.description[0].toUpperCase() +
-            sarviewEvent.description.slice(1)
-        }}</span>
+        <ng-template [ngIf]="!!sarviewEvent.description" [ngIfElse]="NO_DESCRIPTION">
+          <span>
+            {{
+              sarviewEvent.description[0].toUpperCase() +
+                sarviewEvent.description.slice(1)
+            }}
+          </span>
+        </ng-template>
+        <ng-template #NO_DESCRIPTION>
+          <span>
+            {{sarviewEvent.event_type[0].toLocaleUpperCase()}}{{sarviewEvent.event_type.slice(1)}}
+            Event: {{sarviewEvent.processing_timeframe.start | shortDate}}
+          </span>
+        </ng-template>
+
         <app-copy-to-clipboard
         [value]="getEventID()"
         [prompt]="'Copied Event ID'"

--- a/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.html
+++ b/src/app/components/results-menu/scenes-list/sarview-event/sarviews-event.component.html
@@ -14,12 +14,20 @@
   <div class="div-flex">
     <div class="div-flex-column">
       <div class="div-flex"
-      [title]="event.description"
+      [title]="event.description ?? event.event_id"
       class="bold" matLine>
         <span>
-          <span>
-            {{event.description}}
-          </span>
+          <ng-template [ngIf]="!!event.description" [ngIfElse]="NO_DESCRIPTION">
+            <span>
+              {{event.description}}
+            </span>
+          </ng-template>
+
+          <ng-template #NO_DESCRIPTION>
+            <span>
+              {{event.event_type[0].toLocaleUpperCase()}}{{event.event_type.slice(1)}} Event: {{event.processing_timeframe.start | shortDate}}
+            </span>
+          </ng-template>
         </span>
       </div>
     </div>

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -130,7 +130,6 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
         })
       ).subscribe(
         idx => {
-          console.log('aaaihavsdibqwebuiqwbeoqwoubh');
           if (!this.selectedFromList) {
             this.scrollTo(idx);
           }

--- a/src/app/components/shared/selectors/sarviews-event-search-selector/sarviews-event-search-selector.component.html
+++ b/src/app/components/shared/selectors/sarviews-event-search-selector/sarviews-event-search-selector.component.html
@@ -16,9 +16,19 @@
     <mat-option *ngFor="let event of (filteredEvents$ | async)"
         [value]="event.description">
         <div matTooltip = 'event description, id, or type'>
+            <ng-template [ngIf]="!!event.description" [ngIfElse]="NO_DESCRIPTION">
             <span>
               {{event.description}}
             </span>
+          </ng-template>
+
+          <ng-template #NO_DESCRIPTION>
+            <span>
+              {{event.event_type[0].toLocaleUpperCase()}}{{event.event_type.slice(1)}} Event: {{event.processing_timeframe.start | shortDate}}
+            </span>
+          </ng-template>
+
+
         </div>
     </mat-option>
   </mat-autocomplete>

--- a/src/app/components/shared/selectors/sarviews-event-search-selector/sarviews-event-search-selector.module.ts
+++ b/src/app/components/shared/selectors/sarviews-event-search-selector/sarviews-event-search-selector.module.ts
@@ -7,7 +7,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 import { SarviewsEventSearchSelectorComponent } from './sarviews-event-search-selector.component';
-
+import { PipesModule } from '@pipes';
 
 @NgModule({
   declarations: [
@@ -19,6 +19,7 @@ import { SarviewsEventSearchSelectorComponent } from './sarviews-event-search-se
     MatSharedModule,
     MatInputModule,
     MatAutocompleteModule,
+    PipesModule
   ],
   exports: [
     SarviewsEventSearchSelectorComponent

--- a/src/app/services/sarviews-events.service.ts
+++ b/src/app/services/sarviews-events.service.ts
@@ -414,7 +414,7 @@ export class SarviewsEventsService {
             const isQuake = event.event_type.toLowerCase() === 'quake';
             const isVolcano = event.event_type.toLowerCase() === 'volcano';
 
-            return event.description.toLowerCase().includes(nameFilter)
+            return (event.description?.toLowerCase().includes(nameFilter) ?? false)
             || event.event_id.toLowerCase().includes(nameFilter)
             || event.event_type.toLowerCase().includes(nameFilter)
             || (!isVolcano ? (isQuake ? (event as models.SarviewsQuakeEvent).usgs_event_id?.includes(nameFilter) :


### PR DESCRIPTION
Fixes bug where an undefined event description caused event search to break