### PR TITLE
new scale=decibel option for HyP3 RTC_GAMMA jobs

### DIFF
--- a/src/app/models/hyp3-jobs.model.ts
+++ b/src/app/models/hyp3-jobs.model.ts
@@ -44,11 +44,14 @@ export const RtcGammaJobType: Hyp3JobType = {
       name: 'power',
       apiValue: 'power'
     }, {
+      name: 'decibel',
+      apiValue: 'decibel'
+    }, {
       name: 'amplitude',
       apiValue: 'amplitude'
     }],
     default: 'power',
-    info: `Scale of output image; either power or amplitude.`
+    info: `Scale of output image; power, decibel or amplitude.`
   }, {
     name: 'DEM Name',
     apiName: 'dem_name',

--- a/src/app/models/hyp3.model.ts
+++ b/src/app/models/hyp3.model.ts
@@ -108,7 +108,8 @@ export enum RtcGammaResolution {
 
 export enum RtcGammaScale {
   POWER = 'power',
-  AMPLITUDE = 'amplitude'
+  AMPLITUDE = 'amplitude',
+  DECIBEL = 'decibel'
 }
 
 export enum Hyp3JobStatusCode {


### PR DESCRIPTION
Adds support for the new `decibel` option for the `scale` parameter of HyP3 RTC_GAMMA jobs released with [HyP3 2.22.0](https://github.com/ASFHyP3/hyp3/blob/develop/CHANGELOG.md#2220)

When run locally, I get the behavior I expect. The new option and new help text render on both the 'On Demand' and 'Create Subcription' panels. I was able to submit job [1b473c7f-e75e-4987-8e40-a1c938f4241c](https://hyp3-api.asf.alaska.edu/jobs/1b473c7f-e75e-4987-8e40-a1c938f4241c) to HyP3 with `scale=decibel`. When querying my previous job in Vertex, I see "Scale: decibel" shown correctly.

- ![Screenshot from 2022-12-22 14-36-53](https://user-images.githubusercontent.com/17994518/209244316-ce36cf12-cfbe-4965-96d2-a559812c568e.png)
- ![Screenshot from 2022-12-22 14-45-25](https://user-images.githubusercontent.com/17994518/209244366-ebdc0dad-0ae1-46d6-b04b-66a99fbb11be.png)
- ![Screenshot from 2022-12-22 14-42-32](https://user-images.githubusercontent.com/17994518/209244333-5728c6ea-c399-4685-a15e-ae6f67cb0d9f.png)
- ![Screenshot from 2022-12-22 14-44-15](https://user-images.githubusercontent.com/17994518/209244345-46f91ef3-53d4-45fc-800f-771b838def4d.png)
- ![Screenshot from 2022-12-22 14-45-11](https://user-images.githubusercontent.com/17994518/209244356-e4d4bd7e-3ccd-4215-9dab-ebabf0914e14.png)
