### PR TITLE
Bug Fix: Selecting Suggestion now updates On Demand Name Filter

### DIFF
--- a/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.html
+++ b/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.html
@@ -34,7 +34,7 @@
 
     <mat-autocomplete
     [panelWidth] = "isJobFilterOptionsOpen ? 500 : 300"
-    (optionSelected)="onFilterProductName($event.option.value)"
+    (optionSelected)="onSuggestionSelected($event)"
     #jobNameSelector="matAutocomplete">
     <mat-option *ngFor="let fileName of filteredOptionsList"
         [value]="autoCompleteEntry(fileName)">

--- a/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.ts
+++ b/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.ts
@@ -10,6 +10,7 @@ import { ScenesService, ScreenSizeService } from '@services';
 import { getScenes } from '@store/scenes';
 import { combineLatest } from 'rxjs';
 import { Breakpoints, menuAnimation } from '@models';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 
 @Component({
   selector: 'app-job-product-name-selector',
@@ -86,12 +87,16 @@ export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
     );
   }
 
+  public onSuggestionSelected(event: MatAutocompleteSelectedEvent): void {
+    this.setProductNameFilter(event.option.value);
+  }
+
   public onFilterProductName(event: Event): void {
     const productName = (event.target as HTMLInputElement).value;
     this.setProductNameFilter(productName);
   }
 
-  private setProductNameFilter(productName: string ) {
+  private setProductNameFilter(productName: string) {
     const action = new filtersStore.SetProductNameFilter(productName);
     this.store$.dispatch(action);
   }


### PR DESCRIPTION
Recent update to Angular version causes bug where clicking suggestion doesn't immediately update On Demand Search source/granule name filter.