### PR TITLE
Reverts change to SearchType model

### DIFF
--- a/src/app/components/results-menu/mobile-results-menu/mobile-results-menu.component.ts
+++ b/src/app/components/results-menu/mobile-results-menu/mobile-results-menu.component.ts
@@ -51,7 +51,7 @@ export class MobileResultsMenuComponent implements OnInit, OnDestroy {
       this.store$.select(searchStore.getSearchType).subscribe(
         searchType => {
           this.searchType = searchType;
-          this.view = searchType === 'SBAS_SEARCH' ?
+          this.view = searchType === SearchType.SBAS ?
                       MobileViews.SBAS : MobileViews.LIST;
         }
       )

--- a/src/app/components/shared/save-search-dialog/save-search-dialog.component.html
+++ b/src/app/components/shared/save-search-dialog/save-search-dialog.component.html
@@ -19,7 +19,7 @@
 
   <div class="save-search-filters">
     <div style="margin-bottom: 4px;">
-      <b>{{ search.searchType | translate }}</b>
+      <b>{{ searchTranslation[search.searchType] | translate }}</b>
     </div>
 
     <app-search-filters [search]="search">

--- a/src/app/components/shared/save-search-dialog/save-search-dialog.component.ts
+++ b/src/app/components/shared/save-search-dialog/save-search-dialog.component.ts
@@ -23,6 +23,7 @@ import { AsfLanguageService } from "@services/asf-language.service";
 })
 export class SaveSearchDialogComponent implements OnInit {
   public search: models.Search;
+  public searchTranslation = models.SearchTypeTranslation;
 
   private currentFiltersBySearchType = {};
   public searchType: models.SearchType;

--- a/src/app/components/shared/selectors/search-type-selector/search-type-selector.component.html
+++ b/src/app/components/shared/selectors/search-type-selector/search-type-selector.component.html
@@ -7,10 +7,10 @@
       <button
         [matMenuTriggerFor]="searchTypeMenu" (onMenuOpen)="onSearchTypeMenuOpen()"
         class="button-menu-trigger" color="basic"
-        matTooltip="{{ searchType | translate }}"
+        matTooltip="{{ searchTranslation[searchType] | translate }}"
         mat-button>
         <div class="button-text">
-          {{ searchType | translate }}
+          {{ searchTranslation[searchType] | translate }}
           <span class="mat-select-arrow"></span>
         </div>
       </button>

--- a/src/app/components/shared/selectors/search-type-selector/search-type-selector.component.ts
+++ b/src/app/components/shared/selectors/search-type-selector/search-type-selector.component.ts
@@ -34,6 +34,7 @@ export class SearchTypeSelectorComponent implements OnInit, OnDestroy {
 
 
   public searchType: models.SearchType = models.SearchType.DATASET;
+  public searchTranslation = models.SearchTypeTranslation;
   public datasets = derivedDatasets;
   public breakpoint$ = this.screenSize.breakpoint$;
   public breakpoints = Breakpoints;

--- a/src/app/models/search-type.model.ts
+++ b/src/app/models/search-type.model.ts
@@ -8,4 +8,14 @@ export enum SearchType {
   DERIVED_DATASETS = 'Derived Datasets',
 }
 
+export const SearchTypeTranslation = {
+  'Geographic Search' : 'GEOGRAPHIC_SEARCH',
+  'List Search' : 'LIST_SEARCH',
+  'Baseline Search' : 'BASELINE_SEARCH',
+  'SBAS Search' : 'SBAS_SEARCH',
+  'On Demand' : 'ON_DEMAND',
+  'Event Search' : 'EVENT_SEARCH',
+  'Derived Datasets' : 'DERIVED_DATASETS'
+}
+
 export const SearchTypes = Object.keys(SearchType);

--- a/src/app/models/search-type.model.ts
+++ b/src/app/models/search-type.model.ts
@@ -1,11 +1,11 @@
 export enum SearchType {
-  DATASET = 'GEOGRAPHIC_SEARCH',
-  LIST = 'LIST_SEARCH',
-  BASELINE = 'BASELINE_SEARCH',
-  SBAS = 'SBAS_SEARCH',
-  CUSTOM_PRODUCTS = 'ON_DEMAND',
-  SARVIEWS_EVENTS = 'EVENT_SEARCH',
-  DERIVED_DATASETS = 'DERIVED_DATASETS',
+  DATASET = 'Geographic Search',
+  LIST = 'List Search',
+  BASELINE = 'Baseline Search',
+  SBAS = 'SBAS Search',
+  CUSTOM_PRODUCTS = 'On Demand',
+  SARVIEWS_EVENTS = 'Event Search',
+  DERIVED_DATASETS = 'Derived Datasets',
 }
 
 export const SearchTypes = Object.keys(SearchType);


### PR DESCRIPTION
This addresses a bug affecting saved filters/searches older than the latest deployment (saved search functionality depends on the search type string which had been changed, breaking compatibility with older searches)