### PR TITLE
BUGFIX: geocode works with latest version of openlayers

### DIFF
--- a/src/app/components/shared/aoi-options/geocode-selector/geocode-selector.component.ts
+++ b/src/app/components/shared/aoi-options/geocode-selector/geocode-selector.component.ts
@@ -13,6 +13,7 @@ import { SubSink } from 'subsink';
 import { AppState } from '@store';
 import { Store } from '@ngrx/store';
 import { getGeocodeArea } from '@store/filters';
+import { Feature } from 'ol';
 
 @Component({
   selector: 'app-geocode-selector',
@@ -73,9 +74,9 @@ export class GeocodeSelectorComponent implements OnInit, OnDestroy {
 
   public onSelect(option) {
     this.search_key = option.name;
-    let feature = this.vectorSource.getFeatures().find(feat => feat.getId() === option.id);
-
-    let zoomExtent = transformExtent(option.bbox, 'EPSG:4326', this.mapService.epsg());
+    let feature: Feature = this.vectorSource.getFeatures().find(feat => feat.getId() === option.id);
+    
+    let zoomExtent = transformExtent(feature.getGeometry().getExtent(), 'EPSG:4326', this.mapService.epsg());
     this.mapService.zoomToExtent(zoomExtent);
 
     let wktFeature = this.wkt.featureToWkt(feature, 'EPSG:4326');

--- a/src/app/services/map/map.service.ts
+++ b/src/app/services/map/map.service.ts
@@ -42,6 +42,7 @@ import TileLayer from 'ol/layer/Tile';
 import SimpleGeometry from 'ol/geom/SimpleGeometry';
 import { SetGeocode } from '@store/filters';
 import ImageSource from 'ol/source/Image';
+import { Extent } from 'ol/extent';
 
 @Injectable({
   providedIn: 'root'
@@ -419,7 +420,7 @@ export class MapService {
   }
 
 
-  public zoomToExtent(extent): void {
+  public zoomToExtent(extent: Extent): void {
     this.map
       .getView()
       .fit(extent, {


### PR DESCRIPTION
- Fixes not zooming to the provided geocode location
- Adds param type check for mapService's `zoomToExtent()` method