### PR TITLE
SBAS/Baseline Count Query Change

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -493,7 +493,9 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private updateMaxSearchResults(): void {
     const checkAmount = this.searchParams$.getlatestParams().pipe(
-      filter(_ => this.searchType !== SearchType.SARVIEWS_EVENTS),
+      filter(_ => this.searchType !== SearchType.SARVIEWS_EVENTS 
+        && this.searchType !== SearchType.BASELINE 
+        && this.searchType !== SearchType.SBAS),
       debounceTime(200),
       map(params => ({...params, output: 'COUNT'})),
       tap(_ =>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -493,8 +493,8 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private updateMaxSearchResults(): void {
     const checkAmount = this.searchParams$.getlatestParams().pipe(
-      filter(_ => this.searchType !== SearchType.SARVIEWS_EVENTS 
-        && this.searchType !== SearchType.BASELINE 
+      filter(_ => this.searchType !== SearchType.SARVIEWS_EVENTS
+        && this.searchType !== SearchType.BASELINE
         && this.searchType !== SearchType.SBAS),
       debounceTime(200),
       map(params => ({...params, output: 'COUNT'})),

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -71,8 +71,8 @@ export class SearchEffects {
     ofType<SetSearchAmount>(SearchActionType.SET_SEARCH_AMOUNT),
     withLatestFrom(this.store$.select(getSearchType)),
     map(([action, searchType]) =>
-      (action.payload > 0 
-      || searchType === SearchType.BASELINE 
+      (action.payload > 0
+      || searchType === SearchType.BASELINE
       || searchType === SearchType.SBAS) ? new EnableSearch() : new DisableSearch()
     )
   ));
@@ -88,7 +88,7 @@ export class SearchEffects {
   public makeSearches = createEffect(() => this.actions$.pipe(
     ofType(SearchActionType.MAKE_SEARCH),
     withLatestFrom(this.store$.select(getSearchType)),
-    switchMap(([_, searchType]) => 
+    switchMap(([_, searchType]) =>
     {
       if (searchType === SearchType.SARVIEWS_EVENTS) {
         return this.sarviewsEventsQuery$();

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -69,8 +69,11 @@ export class SearchEffects {
 
   public setCanSearch = createEffect(() => this.actions$.pipe(
     ofType<SetSearchAmount>(SearchActionType.SET_SEARCH_AMOUNT),
-    map(action =>
-      (action.payload > 0) ? new EnableSearch() : new DisableSearch()
+    withLatestFrom(this.store$.select(getSearchType)),
+    map(([action, searchType]) =>
+      (action.payload > 0 
+      || searchType === SearchType.BASELINE 
+      || searchType === SearchType.SBAS) ? new EnableSearch() : new DisableSearch()
     )
   ));
 
@@ -85,9 +88,20 @@ export class SearchEffects {
   public makeSearches = createEffect(() => this.actions$.pipe(
     ofType(SearchActionType.MAKE_SEARCH),
     withLatestFrom(this.store$.select(getSearchType)),
-    switchMap(([_, searchType]) => searchType !== models.SearchType.CUSTOM_PRODUCTS ?
-      (searchType === models.SearchType.SARVIEWS_EVENTS ? this.sarviewsEventsQuery$() : this.asfApiQuery$()) :
-      this.customProductsQuery$()
+    switchMap(([_, searchType]) => 
+    {
+      if (searchType === SearchType.SARVIEWS_EVENTS) {
+        return this.sarviewsEventsQuery$();
+      }
+      if (searchType === SearchType.BASELINE || searchType === SearchType.SBAS) {
+        return this.asfApiBaselineQuery$();
+      }
+      if (searchType === SearchType.CUSTOM_PRODUCTS) {
+        return this.customProductsQuery$();
+      }
+
+      return this.asfApiQuery$();
+    }
     )
   ));
 
@@ -250,6 +264,39 @@ export class SearchEffects {
               searchType
             }) :
             new SearchCanceled()
+        ),
+        catchError(
+          (err: HttpErrorResponse) => {
+            if (err.status !== 400) {
+              return of(new SearchError(`Unknown Error`));
+            }
+            return EMPTY;
+          }
+        ),
+      ))
+    );
+  }
+
+  public asfApiBaselineQuery$(): Observable<Action> {
+    this.logCountries();
+    return this.searchParams$.getParams().pipe(
+    switchMap(
+      (params) =>
+        this.asfApiService.query<any[]>(params).pipe(
+        withLatestFrom(combineLatest(
+          this.store$.select(getSearchType),
+          this.store$.select(getIsCanceled)
+        )),
+        map(([response, [searchType, isCanceled]]) => {
+          const files = this.productService.fromResponse(response)
+          return !isCanceled ?
+            new SearchResponse({
+              files,
+              totalCount: files.length,
+              searchType
+            }) :
+            new SearchCanceled()
+          }
         ),
         catchError(
           (err: HttpErrorResponse) => {


### PR DESCRIPTION
Baseline and SBAS query the baseline endpoint for count and params, which fires off an entire SearchAPI baseline stack query just for count, alongside the regular jsonlite2 search. Disabling count on baseline and sbas saves us calculating the same stack twice in SearchAPI.

- baseline and sbas no longer fire off separate count query, count pulled from final results instead