### PR TITLE
SBAS and rxjs

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -344,9 +344,9 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewChecked {
     );
 
     this.subs.add(
-      combineLatest(
+      combineLatest([
         this.store$.select(queueStore.getQueuedJobs),
-        this.store$.select(hyp3Store.getProcessingOptions)
+        this.store$.select(hyp3Store.getProcessingOptions)]
       ).subscribe(
        ([jobs, options]) => localStorage.setItem(
          this.customProductsQueueStateKey, JSON.stringify({jobs, options})

--- a/src/app/components/filters-dropdown/list-filters/list-filters.component.ts
+++ b/src/app/components/filters-dropdown/list-filters/list-filters.component.ts
@@ -109,7 +109,7 @@ export class ListFiltersComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      combineLatest(
+      combineLatest([
       this.actions$.pipe(
         ofType(
           searchStore.SearchActionType.SET_SEARCH_TYPE_AFTER_SAVE,
@@ -117,7 +117,7 @@ export class ListFiltersComponent implements OnInit, OnDestroy {
           filtersStore.FiltersActionType.RESTORE_FILTERS
         ),
         withLatestFrom(this.store$.select(filtersStore.getSearchList).pipe(map(list => list.join('\n')))),
-      )).subscribe(([[_, listStr]]) => this.searchList = listStr
+      )]).subscribe(([[_, listStr]]) => this.searchList = listStr
       )
     );
 

--- a/src/app/components/header/processing-queue/processing-queue-jobs/processing-queue-jobs.component.ts
+++ b/src/app/components/header/processing-queue/processing-queue-jobs/processing-queue-jobs.component.ts
@@ -33,7 +33,7 @@ export class ProcessingQueueJobsComponent implements OnInit {
   // change detection keeps updating the view when it shouldn't causing flickering.
   // this observable ensures we only update the dispalyed processing queue list when the values actually change
   // or when the user changes the sorting order.
-  jobsfiltered$ = combineLatest(this.jobs$.pipe(distinctUntilChanged()), this.sortChange$).pipe(
+  jobsfiltered$ = combineLatest([this.jobs$.pipe(distinctUntilChanged()), this.sortChange$]).pipe(
     map(([jobs, _]) => jobs),
     filter(jobs => !!jobs),
     map(jobs => this.sortJobQueue(jobs)));

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -81,9 +81,9 @@ export class MapComponent implements OnInit, OnDestroy  {
   private subs = new SubSink();
   private gridlinesActive$ = this.store$.select(mapStore.getAreGridlinesActive);
   private isMapInitialized$ = this.store$.select(mapStore.getIsMapInitialization);
-  private viewType$ = combineLatest(
+  private viewType$ = combineLatest([
     this.store$.select(mapStore.getMapView),
-    this.store$.select(mapStore.getMapLayerType),
+    this.store$.select(mapStore.getMapLayerType),]
   );
 
   private sarviewsEvents: SarviewsEvent[];
@@ -131,9 +131,9 @@ export class MapComponent implements OnInit, OnDestroy  {
     );
 
     this.subs.add(
-      combineLatest(
+      combineLatest([
         this.store$.select(uiStore.getIsResultsMenuOpen),
-        this.mapService.searchPolygon$
+        this.mapService.searchPolygon$]
       ).pipe(
         filter(_ => !!this.overlay),
         map(([isResultsMenuOpen, polygon]) => !isResultsMenuOpen && !!polygon),
@@ -186,10 +186,10 @@ export class MapComponent implements OnInit, OnDestroy  {
     );
 
     this.subs.add(
-      combineLatest(
+      combineLatest([
         this.mapService.isDrawing$,
         this.drawMode$,
-        this.interactionMode$
+        this.interactionMode$]
       ).pipe(
         map(([isDrawing, drawMode, interactionMode]) => {
           if (interactionMode === models.MapInteractionModeType.DRAW) {

--- a/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
+++ b/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
@@ -70,7 +70,7 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
     this.subs.add(
       combineLatest([
         this.scenesService.products$(),
-        this.pairService.pairs$()]
+        this.pairService.pairs$]
       ).subscribe(
         ([products, {pairs, custom}]) => {
           this.products = products;
@@ -97,7 +97,7 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      this.pairService.productsFromPairs$().subscribe(
+      this.pairService.productsFromPairs$.subscribe(
         products => this.sbasProducts = products
       )
     );

--- a/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
+++ b/src/app/components/results-menu/baseline-results-menu/baseline-results-menu.component.ts
@@ -68,9 +68,9 @@ export class BaselineResultsMenuComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.subs.add(
-      combineLatest(
+      combineLatest([
         this.scenesService.products$(),
-        this.pairService.pairs$()
+        this.pairService.pairs$()]
       ).subscribe(
         ([products, {pairs, custom}]) => {
           this.products = products;

--- a/src/app/components/results-menu/scene-files/file-contents/file-contents.component.ts
+++ b/src/app/components/results-menu/scene-files/file-contents/file-contents.component.ts
@@ -60,9 +60,9 @@ export class FileContentsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.subs.add(
-      combineLatest(
+      combineLatest([
         this.store$.select(scenesStore.getUnzippedProducts),
-        this.store$.select(scenesStore.getOpenUnzippedProduct)
+        this.store$.select(scenesStore.getOpenUnzippedProduct)]
       ).pipe(
         tap(([_, product]) => this.product = product),
         map(([unzipped, product]) => unzipped[product ? product.id : null]),

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -115,10 +115,10 @@ export class SceneFilesComponent implements OnInit, OnDestroy, AfterContentInit 
 
   ngOnInit() {
     this.subs.add(
-      combineLatest(
+      combineLatest([
         this.store$.select(scenesStore.getSelectedSceneProducts),
         this.store$.select(scenesStore.getOpenUnzippedProduct),
-        this.store$.select(scenesStore.getUnzippedProducts)
+        this.store$.select(scenesStore.getUnzippedProducts)]
       ).pipe(debounceTime(0))
       .subscribe(
         ([products, unzipped, unzippedFiles]) => {

--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.ts
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component,  OnDestroy, OnInit } from '@angular/core';
 import { saveAs } from 'file-saver';
 
-import { combineLatest } from 'rxjs';
+import { combineLatest,  } from 'rxjs';
 import { debounceTime, filter, map } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
@@ -31,11 +31,15 @@ import { ClipboardService } from 'ngx-clipboard';
 })
 export class ScenesListHeaderComponent implements OnInit, OnDestroy {
   public copyIcon = faCopy;
-  public totalResultCount$ = combineLatest(
+  public pairs$ = this.pairService.pairs$;
+  private pairProducts$ = this.pairService.productsFromPairs$;
+
+
+  public totalResultCount$ = combineLatest([
     this.store$.select(searchStore.getTotalResultCount),
-    this.scenesService.scenes$()
-    ).pipe(
-      map(([count, scenes]) => count + scenes?.filter(scene => scene.metadata.productType === 'BURST').length)
+    this.scenesService.scenes$()]
+  ).pipe(
+    map(([count, scenes]) => count + scenes?.filter(scene => scene.metadata.productType === 'BURST').length)
   )
 
   public currentDatasetID$ = this.store$.select(filtersStore.getSelectedDataset).pipe(map(dataset => dataset.id));
@@ -58,7 +62,7 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
   public isBurstStack$ =
   combineLatest([
     this.scenesService.products$(),
-    this.pairService.pairs$(),
+    this.pairService.pairs$,
     this.store$.select(searchStore.getSearchType),
   ]
   ).pipe(
@@ -72,7 +76,7 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
     )
   )
   )
-  public numPairs$ = this.pairService.pairs$().pipe(
+  public numPairs$ = this.pairService.pairs$.pipe(
     filter(pairs => !!pairs),
     map(pairs => pairs.pairs.length + pairs.custom.length)
   );
@@ -94,10 +98,10 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
     map(products => products.filter(p => p.metadata.productType === 'BURST'))
   );
 
-  public SBASburstDataProducts$ = combineLatest(
+  public SBASburstDataProducts$ = combineLatest([
     this.burstDataProducts$,
-    this.pairService.productsFromPairs$()
-    ).pipe(
+    this.pairProducts$]
+  ).pipe(
     map(([products, pairs]) => {
       const pairNames = pairs.map(p => p.name);
       const output = products.filter(p => pairNames.find(name => name === p.name));
@@ -109,10 +113,10 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
     map(products => products.filter(p => p.metadata.productType === 'BURST_XML'))
   );
 
-  public SBASburstMetadataProducts$ = combineLatest(
+  public SBASburstMetadataProducts$ = combineLatest([
     this.burstMetadataProducts$,
-    this.pairService.productsFromPairs$()
-    ).pipe(
+    this.pairProducts$]
+  ).pipe(
     map(([products, pairs]) => {
       const pairNames = pairs.map(p => p.name);
       const output = products.filter(p => pairNames.find(name => name === p.name));
@@ -120,9 +124,9 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
     })
   );
 
-  public SBASBurstProductsLength$ = combineLatest(
+  public SBASBurstProductsLength$ = combineLatest([
     this.SBASburstDataProducts$.pipe(map(products => products.length)),
-    this.SBASburstMetadataProducts$.pipe(map(products => products.length))
+    this.SBASburstMetadataProducts$.pipe(map(products => products.length))]
   ).pipe(map(([data, metadata]) => data + metadata))
 
   public pairs: models.CMRProductPair[];
@@ -169,20 +173,21 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.subs.add(
-       this.pairService.productsFromPairs$().subscribe(
-         products => this.sbasProducts = products
-       )
+      this.pairProducts$.subscribe(
+        products => this.sbasProducts = products
+      )
     );
 
     this.subs.add(
-      combineLatest(
+      combineLatest([
         this.scenesService.products$(),
-        this.pairService.pairs$()
+        this.pairs$
+      ]
       ).subscribe(
-        ([products, {pairs, custom}]) => {
+        ([products, { pairs, custom }]) => {
           this.products = products;
           this.downloadableProds = this.hyp3.downloadable(products);
-          this.pairs = [ ...pairs, ...custom ];
+          this.pairs = [...pairs, ...custom];
 
           this.hyp3able = this.hyp3.getHyp3ableProducts([
             ...this.products.map(prod => [prod]),
@@ -193,10 +198,10 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      combineLatest(
+      combineLatest([
         this.scenesService.scenes$(),
         this.store$.select(filtersStore.getProductTypes),
-        this.store$.select(searchStore.getSearchType),
+        this.store$.select(searchStore.getSearchType),]
       ).pipe(
         debounceTime(250)
       ).subscribe(([scenes, productTypes, searchType]) => {
@@ -246,7 +251,7 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
     this.subs.add(
       this.store$.select(queueStore.getQueuedProducts).subscribe(
         products => this.queuedProducts = products
-        )
+      )
     );
 
     this.subs.add(
@@ -386,15 +391,15 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
 
   public onQueueSarviewsProducts(products: models.SarviewsProduct[]): void {
     this.store$.dispatch(new AddItems(products.map(product =>
-        this.eventMonitoringService.eventProductToCMRProduct(product))
-      ));
+      this.eventMonitoringService.eventProductToCMRProduct(product))
+    ));
   }
 
   public addOnDemandEventProducts(targetProducts: SarviewsProduct[]) {
     const jobs: models.QueuedHyp3Job[] = targetProducts.map(prod => ({
-      granules:  this.eventMonitoringService.getSourceCMRProducts(prod),
+      granules: this.eventMonitoringService.getSourceCMRProducts(prod),
       job_type: hyp3JobTypes[prod.job_type]
-      })
+    })
     );
 
     this.store$.dispatch(new AddJobs(jobs));
@@ -423,13 +428,13 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
 
   public getProductSceneCount(products: SarviewsProduct[]) {
     const outputList = products.reduce((prev, product) => {
-        const temp = product.granules.map(granule => granule.granule_name);
+      const temp = product.granules.map(granule => granule.granule_name);
 
-        prev = prev.concat(temp);
+      prev = prev.concat(temp);
 
-        return prev;
+      return prev;
 
-        }, [] as string[]
+    }, [] as string[]
     );
 
     return new Set(outputList).size;
@@ -437,16 +442,16 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
 
   public getProductDownloadUrl(products: SarviewsProduct[]) {
     const productListStr = products.map(product => product.files.product_url);
-    this.clipboard.copyFromContent( productListStr.join('\n '));
+    this.clipboard.copyFromContent(productListStr.join('\n '));
     const lines = products.length;
     this.notificationService.clipboardCopyQueue(lines, false);
   }
 
   public onAddEventToOnDemand(product: SarviewsProduct) {
     const job: models.QueuedHyp3Job = {
-      granules:  this.eventMonitoringService.getSourceCMRProducts(product),
+      granules: this.eventMonitoringService.getSourceCMRProducts(product),
       job_type: hyp3JobTypes[product.job_type]
-      };
+    };
 
     this.store$.dispatch(new queueStore.AddJob(job));
   }
@@ -454,10 +459,10 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
   public copyProductSourceScenes(products: SarviewsProduct[]) {
     const granuleNameList = products.reduce(
       (acc, curr) => acc = acc.concat(curr.granules), [] as models.SarviewProductGranule[]
-      ).map(gran => gran.granule_name);
+    ).map(gran => gran.granule_name);
     const granuleNameListSet = new Set(granuleNameList);
 
-    this.clipboard.copyFromContent( Array.from(granuleNameListSet).join(','));
+    this.clipboard.copyFromContent(Array.from(granuleNameListSet).join(','));
     this.notificationService.clipboardCopyIcon('', granuleNameListSet.size);
   }
 

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -27,6 +27,7 @@ import { CMRProduct, QueuedHyp3Job, SarviewsEvent } from '@models';
 export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit {
   @ViewChild(CdkVirtualScrollViewport, { static: true }) scroll: CdkVirtualScrollViewport;
   @Input() resize$: Observable<void>;
+  private pairs$ = this.pairService.pairs$;
 
   public scenes: CMRProduct[];
   public pairs;
@@ -164,7 +165,7 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
     );
 
     this.subs.add(
-      this.pairService.pairs$().pipe(debounceTime(250)).subscribe(
+      this.pairs$.subscribe(
         pairs => {
           this.pairs = [...pairs.pairs, ...pairs.custom].map(
             pair => {
@@ -266,7 +267,7 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
 
     this.subs.add(
       this.store$.select(scenesStore.getSelectedPair).pipe(
-        withLatestFrom(this.pairService.pairs$()),
+        withLatestFrom(this.pairs$),
         delay(20),
         filter(([selected, _]) => !!selected),
         map(([selected, pairs]) => {
@@ -312,7 +313,7 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
       }
     ));
 
-    this.subs.add(this.pairService.pairs$().pipe(
+    this.subs.add(this.pairs$.pipe(
       filter(loaded => !!loaded),
       withLatestFrom(this.store$.select(scenesStore.getSelectedPair)),
       map(([pairs, selected]) => ({ selectedPair: selected, pairs })),

--- a/src/app/components/results-menu/scenes-list/scenes-list.component.ts
+++ b/src/app/components/results-menu/scenes-list/scenes-list.component.ts
@@ -201,9 +201,9 @@ export class ScenesListComponent implements OnInit, OnDestroy, AfterContentInit 
       }
     );
 
-    const queueScenes$ = combineLatest(
+    const queueScenes$ = combineLatest([
       this.store$.select(queueStore.getQueuedProducts),
-      this.store$.select(scenesStore.getAllSceneProducts),
+      this.store$.select(scenesStore.getAllSceneProducts),]
     ).pipe(
       debounceTime(0),
       map(([queueProducts, searchScenes]) => {

--- a/src/app/components/sbas-chart/sbas-chart.component.ts
+++ b/src/app/components/sbas-chart/sbas-chart.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, Input, Output, EventEmitter} from '@angular/core';
 
-import { combineLatest, Observable } from 'rxjs';
-import { distinctUntilChanged, map, tap } from 'rxjs/operators';
+import {  Observable, combineLatest } from 'rxjs';
+import {  distinctUntilChanged, map, tap,  } from 'rxjs/operators';
 
 import * as d3 from 'd3';
 import { Store } from '@ngrx/store';
@@ -32,7 +32,7 @@ export class SBASChartComponent implements OnInit, OnDestroy {
   @Input() zoomIn$: Observable<void>;
   @Input() zoomOut$: Observable<void>;
   @Input() zoomToFit$: Observable<void>;
-
+  private pairs$: Observable<any> = this.pairService.pairs$;
   @Output() isGraphDisconnected = new EventEmitter<boolean>();
 
   private hoveredLine;
@@ -74,7 +74,6 @@ export class SBASChartComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const scenes$ = this.scenesService.scenes$();
-    const pairs$ = this.pairService.pairs$();
 
     this.store$.select(scenesStore.getSelectedPair).pipe(
       map(pair => !!pair?.[0] && !!pair?.[1] ? pair : null)
@@ -93,7 +92,7 @@ export class SBASChartComponent implements OnInit, OnDestroy {
     this.subs.add(
       combineLatest([
         scenes$.pipe(distinctUntilChanged()),
-        pairs$.pipe(distinctUntilChanged())
+        this.pairs$
       ]).subscribe(([scenes, pairs]) => {
         this.scenes = scenes;
         this.pairs = pairs.pairs;

--- a/src/app/components/shared/max-results-selector/api-link-dialog/api-link-dialog.component.ts
+++ b/src/app/components/shared/max-results-selector/api-link-dialog/api-link-dialog.component.ts
@@ -55,8 +55,9 @@ export class ApiLinkDialogComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.subs.add(
-      combineLatest(
-        this.amount$, this.format$
+      combineLatest([
+        this.amount$,
+        this.format$]
       ).pipe(
         tap(([amount, format]) => {
           this.amount = amount;

--- a/src/app/components/shared/max-results-selector/max-results-selector.component.ts
+++ b/src/app/components/shared/max-results-selector/max-results-selector.component.ts
@@ -77,7 +77,7 @@ export class MaxResultsSelectorComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      this.pairService.productsFromPairs$().subscribe(
+      this.pairService.productsFromPairs$.subscribe(
         products => this.sbasProducts = products
       )
     );

--- a/src/app/components/shared/search-button/search-button.component.ts
+++ b/src/app/components/shared/search-button/search-button.component.ts
@@ -106,8 +106,9 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      combineLatest(this.store$.select(getFilterMaster),
-      this.store$.select(uiStore.getIsFiltersMenuOpen)).subscribe(([latestFilter, isOpen]) => {
+      combineLatest([
+        this.store$.select(getFilterMaster),
+        this.store$.select(uiStore.getIsFiltersMenuOpen)]).subscribe(([latestFilter, isOpen]) => {
       if (isOpen && this.searchType === this.searchTypes.BASELINE || this.searchType === this.searchTypes.SBAS) {
           this.latestReferenceScene = latestFilter;
           if (this.stackReferenceScene == null || '') {

--- a/src/app/services/asf-api.service.ts
+++ b/src/app/services/asf-api.service.ts
@@ -167,7 +167,7 @@ export class AsfApiService {
   }
 
   public loadMissions$() {
-    return combineLatest(
+    return combineLatest([
       this.missionSearch(MissionDataset.S1_BETA).pipe(
         map(resp => ({[MissionDataset.S1_BETA]: resp.result}))
       ),
@@ -176,7 +176,7 @@ export class AsfApiService {
       ),
       this.missionSearch(MissionDataset.UAVSAR).pipe(
         map(resp => ({[MissionDataset.UAVSAR]: resp.result}))
-      )
+      )]
     ).pipe(
       map(missions => missions.reduce(
         (allMissions, mission) => ({ ...allMissions, ...mission }),

--- a/src/app/services/date-extrema.service.ts
+++ b/src/app/services/date-extrema.service.ts
@@ -22,8 +22,9 @@ export class DateExtremaService {
         map(selected => selected.date.start)
     );
 
-    const startMax$ = combineLatest(
-      selectedDataset$, endDate$
+    const startMax$ = combineLatest([
+      selectedDataset$,
+      endDate$]
     ).pipe(
       map(([selected, userEnd]) => {
         if (!!userEnd) {
@@ -34,9 +35,9 @@ export class DateExtremaService {
       })
     );
 
-    const endMin$ = combineLatest(
+    const endMin$ = combineLatest([
       selectedDataset$,
-      startDate$
+      startDate$]
     ).pipe(
       map(([selected, userStart]) => {
         if (!!userStart) {
@@ -51,7 +52,7 @@ export class DateExtremaService {
       map(selected => selected.date.end || new Date(Date.now()))
     );
 
-    return combineLatest(startMin$, startMax$, endMin$, endMax$).pipe(
+    return combineLatest([startMin$, startMax$, endMin$, endMax$]).pipe(
       map(extrema => this.buildExtrema(...extrema)),
     );
   }
@@ -73,8 +74,9 @@ export class DateExtremaService {
 
     const startMin$ = sceneMin$;
 
-    const startMax$ = combineLatest(
-      sceneMax$, endDate$
+    const startMax$ = combineLatest([
+      sceneMax$,
+      endDate$]
     ).pipe(
       map(([sceneMax, userEnd]) => {
         if (!!userEnd) {
@@ -85,9 +87,9 @@ export class DateExtremaService {
       })
     );
 
-    const endMin$ = combineLatest(
+    const endMin$ = combineLatest([
       sceneMin$,
-      startDate$
+      startDate$]
     ).pipe(
       map(([sceneMin, userStart]) => {
         if (!!userStart) {

--- a/src/app/services/pair.service.ts
+++ b/src/app/services/pair.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { Observable, combineLatest } from 'rxjs';
-import {  map,  distinctUntilChanged, shareReplay, debounceTime } from 'rxjs/operators';
+import { map, distinctUntilChanged, shareReplay, debounceTime } from 'rxjs/operators';
 
 import { Store } from '@ngrx/store';
 import { AppState } from '@store/app.reducer';
@@ -10,7 +10,7 @@ import {
   getTemporalRange, getPerpendicularRange, getDateRange, DateRangeState, getSeason, getSBASOverlapThreshold
 } from '@store/filters/filters.reducer';
 
-import { CMRProduct, CMRProductPair, ColumnSortDirection, Range, SBASOverlap,  } from '@models';
+import { CMRProduct, CMRProductPair, ColumnSortDirection, Range, SBASOverlap, } from '@models';
 import { MapService } from './map/map.service';
 import { WktService } from './wkt.service';
 
@@ -32,54 +32,54 @@ export class PairService {
 
 
   public pairs$: Observable<{ custom: CMRProductPair[], pairs: CMRProductPair[] }> = combineLatest([
-      this.store$.select(getScenes).pipe(
-        map(
-          scenes => this.temporalSort(scenes, ColumnSortDirection.INCREASING)
-        ),
+    this.store$.select(getScenes).pipe(
+      map(
+        scenes => this.temporalSort(scenes, ColumnSortDirection.INCREASING)
       ),
-      this.store$.select(getCustomPairs),
-      this.store$.select(getTemporalRange),
-      this.store$.select(getPerpendicularRange).pipe(
-        map(range => range.start)
-      ),
-      this.store$.select(getDateRange),
-      this.store$.select(getSeason),
-      this.store$.select(getSBASOverlapThreshold),
-      this.mapService.searchPolygon$.pipe(
-        map(wkt => !!wkt ? this.wktService.wktToFeature(wkt, this.mapService.epsg()) : null)
-      ),
-    ]).pipe(
-      debounceTime(250),
-      distinctUntilChanged(),
-      map(([scenes, customPairs, temporalRange, perpendicular, dateRange, season, overlap, polygon]) => {
-        console.log('oh making things again')
-        const pairs = this.makePairs(scenes,
-          temporalRange,
-          perpendicular,
-          dateRange,
-          season,
-          overlap,
-          polygon
-          )
-        return {
-          pairs: [...pairs],
-          custom: [...customPairs]
-        }
-      }),
-      shareReplay({ refCount: true, bufferSize: 1 }),
-    )
-    public productsFromPairs$: Observable<CMRProduct[]> = this.pairs$.pipe(
-      map(({ custom, pairs }) => {
-        const prods = Array.from([...custom, ...pairs].reduce((products, pair) => {
-          products.add(pair[0]);
-          products.add(pair[1]);
+    ),
+    this.store$.select(getCustomPairs),
+    this.store$.select(getTemporalRange),
+    this.store$.select(getPerpendicularRange).pipe(
+      map(range => range.start)
+    ),
+    this.store$.select(getDateRange),
+    this.store$.select(getSeason),
+    this.store$.select(getSBASOverlapThreshold),
+    this.mapService.searchPolygon$.pipe(
+      map(wkt => !!wkt ? this.wktService.wktToFeature(wkt, this.mapService.epsg()) : null)
+    ),
+  ]).pipe(
+    debounceTime(50),
+    distinctUntilChanged(),
+    map(([scenes, customPairs, temporalRange, perpendicular, dateRange, season, overlap, polygon]) => {
+      console.log('oh making things again')
+      const pairs = this.makePairs(scenes,
+        temporalRange,
+        perpendicular,
+        dateRange,
+        season,
+        overlap,
+        polygon
+      )
+      return {
+        pairs: [...pairs],
+        custom: [...customPairs]
+      }
+    }),
+    shareReplay({ refCount: true, bufferSize: 1 }),
+  )
+  public productsFromPairs$: Observable<CMRProduct[]> = this.pairs$.pipe(
+    map(({ custom, pairs }) => {
+      const prods = Array.from([...custom, ...pairs].reduce((products, pair) => {
+        products.add(pair[0]);
+        products.add(pair[1]);
 
-          return products;
-        }, new Set<CMRProduct>()));
+        return products;
+      }, new Set<CMRProduct>()));
 
-        return prods;
-      })
-    );
+      return prods;
+    })
+  );
   private makePairs(scenes: CMRProduct[], tempThreshold: Range<number>, perpThreshold,
     dateRange: DateRangeState,
     season: Range<number>,
@@ -274,7 +274,7 @@ export class PairService {
   }
 
   public isGraphDisconnected(pairs: any[], numScenes: Number) {
-    if(pairs.length === 0) {
+    if (pairs.length === 0) {
       return false
     }
     let graph_model = {}
@@ -299,13 +299,13 @@ export class PairService {
 
       }
     }
-    if(numScenes !== points.size) {
+    if (numScenes !== points.size) {
       return true;
     }
 
 
     let to_check = []
-    let checked : Set<String> = new Set()
+    let checked: Set<String> = new Set()
     to_check.push(points.values().next().value)
 
     while (to_check.length > 0) {

--- a/src/app/services/pair.service.ts
+++ b/src/app/services/pair.service.ts
@@ -52,7 +52,6 @@ export class PairService {
     debounceTime(50),
     distinctUntilChanged(),
     map(([scenes, customPairs, temporalRange, perpendicular, dateRange, season, overlap, polygon]) => {
-      console.log('oh making things again')
       const pairs = this.makePairs(scenes,
         temporalRange,
         perpendicular,
@@ -112,7 +111,6 @@ export class PairService {
       centroid.lat = centroid.lat / 4.0;
       return centroid;
     };
-    console.time('pair making')
     scenes.forEach((root, index) => {
 
       if (!!aoi) {
@@ -195,8 +193,6 @@ export class PairService {
         pairs.push([root, scene]);
       }
     });
-    console.timeEnd('pair making')
-    console.log(pairs) // for some reason this takes like no time at all on the base search but still spits out results???????
 
 
     return pairs;

--- a/src/app/services/sarviews-events.service.ts
+++ b/src/app/services/sarviews-events.service.ts
@@ -386,8 +386,10 @@ export class SarviewsEventsService {
   }
 
   public areEventProductsFiltered$(): Observable<Boolean> {
-    return combineLatest(this.filteredEventProducts$(),
-      this.store$.select(getSelectedSarviewsEventProducts)).pipe(
+    return combineLatest([
+      this.filteredEventProducts$(),
+      this.store$.select(getSelectedSarviewsEventProducts)]
+      ).pipe(
         map(([filtered, unfiltered]) => {
           if (!!unfiltered) {
             return !(filtered?.length === unfiltered.length);

--- a/src/app/services/saved-search.service.ts
+++ b/src/app/services/saved-search.service.ts
@@ -23,11 +23,11 @@ import { getSarviewsMagnitudeRange } from '@store/filters';
 })
 export class SavedSearchService {
 
-  private currentGeographicSearch$ = combineLatest(
+  private currentGeographicSearch$ = combineLatest([
     this.store$.select(filtersStore.getGeographicSearch).pipe(
       map(filters =>  ({ ...filters, flightDirections: Array.from(filters.flightDirections) })),
     ),
-    this.mapService.searchPolygon$
+    this.mapService.searchPolygon$]
   ).pipe(
     map(([filters, polygon]): models.GeographicFiltersType => ({
       ...filters,
@@ -36,10 +36,10 @@ export class SavedSearchService {
   );
 
   private currentListSearch$ = this.store$.select(filtersStore.getListSearch);
-  private currentBaselineSearch$ = combineLatest(
+  private currentBaselineSearch$ = combineLatest([
     this.store$.select(scenesStore.getFilterMaster),
     this.store$.select(scenesStore.getMasterName),
-    this.store$.select(filtersStore.getBaselineSearch),
+    this.store$.select(filtersStore.getBaselineSearch),]
   ).pipe(
     map(([filterMaster, reference, baselineFilters]) => ({
       filterMaster,
@@ -48,12 +48,12 @@ export class SavedSearchService {
     }))
   );
 
-  private currentSbasSearch$: Observable<models.SbasFiltersType> = combineLatest(
+  private currentSbasSearch$: Observable<models.SbasFiltersType> = combineLatest([
     this.store$.select(scenesStore.getFilterMaster),
     this.store$.select(scenesStore.getCustomPairIds),
     this.store$.select(filtersStore.getSbasSearch),
     this.store$.select(filtersStore.getDateRange),
-    this.store$.select(filtersStore.getSBASOverlapThreshold),
+    this.store$.select(filtersStore.getSBASOverlapThreshold),]
   ).pipe(
     map(([reference, customPairIds, sbasFilters, dateRange, thresholdOverlap]) => ({
       reference,
@@ -64,12 +64,12 @@ export class SavedSearchService {
       ...sbasFilters
     }))
   );
-  private currentCustomProductSearch$ = combineLatest(
+  private currentCustomProductSearch$ = combineLatest([
     this.store$.select(filtersStore.getJobStatuses),
     this.store$.select(filtersStore.getDateRange),
     this.store$.select(filtersStore.getProjectName),
     this.store$.select(filtersStore.getProductNameFilter),
-    this.store$.select(filtersStore.getCustomProductSearch)
+    this.store$.select(filtersStore.getCustomProductSearch)]
   ).pipe(
     map(([jobStatuses, dateRange, projectName, productFilterName, customProductFilters]) => ({
       jobStatuses,
@@ -80,7 +80,7 @@ export class SavedSearchService {
     }))
   );
 
-  private currentSarviewsEventSearch$ = combineLatest(
+  private currentSarviewsEventSearch$ = combineLatest([
     this.store$.select(filtersStore.getDateRange),
     this.store$.select(filtersStore.getSarviewsEventTypes),
     this.store$.select(filtersStore.getSarviewsEventNameFilter),
@@ -91,7 +91,7 @@ export class SavedSearchService {
     this.store$.select(filtersStore.getHyp3ProductTypes).pipe(
       map(productTypes => productTypes.map(productType => productType.id))
     ),
-    this.store$.select(filtersStore.getPathFrameRanges),
+    this.store$.select(filtersStore.getPathFrameRanges),]
   ).pipe(
     map(([dateRange, sarviewsEventTypes, sarviewsEventNameFilter,
       activeOnly, magnitude, pinnedProductIDs,

--- a/src/app/services/scenes.service.ts
+++ b/src/app/services/scenes.service.ts
@@ -67,10 +67,10 @@ export class ScenesService {
   }
 
   public sortScenes$(scenes$: Observable<CMRProduct[]>) {
-    return combineLatest(
+    return combineLatest([
       scenes$,
       this.store$.select(getTemporalSortDirection),
-      this.store$.select(getPerpendicularSortDirection)
+      this.store$.select(getPerpendicularSortDirection)]
     ).pipe(
       debounceTime(0),
       map(
@@ -90,11 +90,11 @@ export class ScenesService {
   }
 
   private hideS1Raw$(products$: Observable<CMRProduct[]>) {
-    return combineLatest(
+    return combineLatest([
       products$,
       this.store$.select(getShowS1RawData),
       this.store$.select(getProductTypes),
-      this.store$.select(getSearchType),
+      this.store$.select(getSearchType),]
     ).pipe(
       debounceTime(0),
       map(([ scenes, showS1RawData, productTypes, searchType ]) => {
@@ -125,10 +125,10 @@ export class ScenesService {
   }
 
   private projectNameFilter$(scenes$: Observable<CMRProduct[]>) {
-    return combineLatest(
+    return combineLatest([
       scenes$,
       this.store$.select(getProjectName),
-      this.store$.select(getSearchType),
+      this.store$.select(getSearchType),]
     ).pipe(
       debounceTime(0),
       map(([scenes, projectName, searchType]) => {
@@ -154,10 +154,10 @@ export class ScenesService {
   }
 
   private jobStatusFilter$(scenes$: Observable<CMRProduct[]>) {
-    return combineLatest(
+    return combineLatest([
       scenes$,
       this.store$.select(getJobStatuses),
-      this.store$.select(getSearchType),
+      this.store$.select(getSearchType),]
     ).pipe(
       debounceTime(0),
       map(([scenes, jobStatuses, searchType]) => {
@@ -184,10 +184,10 @@ export class ScenesService {
   }
 
   private hideExpired$(scenes$: Observable<CMRProduct[]>) {
-    return combineLatest(
+    return combineLatest([
       scenes$,
       this.store$.select(getShowExpiredData),
-      this.store$.select(getSearchType),
+      this.store$.select(getSearchType),]
     ).pipe(
       debounceTime(200),
       map(([scenes, showExpiredData, searchType]) => {
@@ -209,13 +209,13 @@ export class ScenesService {
   }
 
   private filterBaselineValues$(scenes$: Observable<CMRProduct[]>) {
-    return combineLatest(
+    return combineLatest([
       scenes$,
       this.store$.select(getTemporalRange),
       this.store$.select(getPerpendicularRange),
       this.store$.select(getDateRange),
       this.store$.select(getSearchType),
-      this.store$.select(getSeason),
+      this.store$.select(getSeason),]
     ).pipe(
       debounceTime(20),
       map(([scenes, tempRange, perpRange, dateRange, searchType, season]) => {
@@ -232,10 +232,10 @@ export class ScenesService {
   }
 
   private filterByDate$(scenes$: Observable<CMRProduct[]>) {
-    return combineLatest(
+    return combineLatest([
       scenes$,
       this.store$.select(getDateRange),
-      this.store$.select(getSearchType),
+      this.store$.select(getSearchType),]
     ).pipe(
       debounceTime(0),
       map(

--- a/src/app/services/search-params.service.ts
+++ b/src/app/services/search-params.service.ts
@@ -29,9 +29,9 @@ export class SearchParamsService {
   ) { }
 
   public getParams(): Observable<any> {
-    return combineLatest(
+    return combineLatest([
       this.searchType$(),
-      this.baselineSearchParams$(),
+      this.baselineSearchParams$(),]
     ).pipe(
       withLatestFrom(this.listParam$()),
       withLatestFrom(this.filterSearchParams$()),
@@ -62,11 +62,11 @@ export class SearchParamsService {
   }
 
   public getlatestParams(): Observable<any> {
-    return combineLatest(
+    return combineLatest([
       this.searchType$(),
       this.listParam$(),
       this.baselineSearchParams$(),
-      this.filterSearchParams$()
+      this.filterSearchParams$()]
     ).pipe(
       map(
         ([searchType, listParam, baselineParams, filterParams]) => {
@@ -99,7 +99,7 @@ export class SearchParamsService {
   }
 
   private filterSearchParams$() {
-    return combineLatest(
+    return combineLatest([
       this.searchPolygon$(),
       this.selectedDataset$(),
       this.dateRange$(),
@@ -112,7 +112,7 @@ export class SearchParamsService {
       this.polarizations$(),
       this.maxResults$(),
       this.missionParam$(),
-      this.burstParams$(),
+      this.burstParams$(),]
     ).pipe(
       map((params: any[]) => params
         .reduce(
@@ -152,10 +152,10 @@ export class SearchParamsService {
   }
 
   private searchPolygon$() {
-    return combineLatest(
+    return combineLatest([
       this.mapService.searchPolygon$.pipe(startWith(null)),
       this.store$.select(filterStore.getShouldOmitSearchPolygon),
-      this.drawService.polygon$
+      this.drawService.polygon$]
     ).pipe(
       map(([polygon, shouldOmitGeoRegion, asdf]) => shouldOmitGeoRegion ? null : { polygon: polygon, thing: asdf }),
       map(polygon => {
@@ -198,9 +198,9 @@ export class SearchParamsService {
   }
 
   private selectedDataset$() {
-    return combineLatest(
+    return combineLatest([
       this.store$.select(filterStore.getSelectedDataset),
-      this.store$.select(filterStore.getSubtypes)
+      this.store$.select(filterStore.getSubtypes)]
     ).pipe(
       map(([dataset, subtypes]) => {
         return subtypes.length > 0 ?

--- a/src/app/store/scenes/scenes.reducer.ts
+++ b/src/app/store/scenes/scenes.reducer.ts
@@ -4,6 +4,7 @@ import { ScenesActionType, ScenesActions } from './scenes.action';
 
 import { CMRProduct, UnzippedFolder, ColumnSortDirection, SarviewsEvent, SarviewsProduct } from '@models';
 import { PinnedProduct } from '@services/browse-map.service';
+import { createSelectorFactory, defaultMemoize  } from '@ngrx/store';
 
 interface SceneEntities { [id: string]: CMRProduct; }
 
@@ -360,7 +361,23 @@ export const allScenesWithBrowse = (scenes: {[id: string]: string[]}, products) 
   return withBrowses;
 };
 
-export const getScenes = createSelector(
+function arrayEquals(a, b) {
+  return Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.toString() === b.toString();
+}
+export const createArraySelector =
+  createSelectorFactory(
+    (projectionFn) =>
+      defaultMemoize(
+        projectionFn,
+        arrayEquals,
+        arrayEquals
+      )
+  );
+
+export const getScenes = createArraySelector(
   getScenesState,
   (state: ScenesState) => allScenesFrom(state.scenes, state.products)
 );
@@ -612,7 +629,7 @@ export const getCustomPairIds = createSelector(
   state => state.customPairIds
 );
 
-export const getCustomPairs = createSelector(
+export const getCustomPairs = createArraySelector(
   getScenesState,
   state => state.customPairIds.map(
     pairIds => pairIds.map(id => state.products[id])

--- a/src/app/store/scenes/scenes.reducer.ts
+++ b/src/app/store/scenes/scenes.reducer.ts
@@ -365,7 +365,8 @@ function arrayEquals(a, b) {
   return Array.isArray(a) &&
       Array.isArray(b) &&
       a.length === b.length &&
-      a.toString() === b.toString();
+      a.toString() === b.toString() &&
+      a.every((value, index) => value.toString() === b[index].toString())
 }
 export const createArraySelector =
   createSelectorFactory(

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -258,9 +258,9 @@ export class SearchEffects {
         this.asfApiService.query<any[]>(params),
         this.asfApiService.query<any[]>(countParams)
       ).pipe(
-        withLatestFrom(combineLatest(
+        withLatestFrom(combineLatest([
           this.store$.select(getSearchType),
-          this.store$.select(getIsCanceled)
+          this.store$.select(getIsCanceled)]
         )),
         map(([[response, totalCount], [searchType, isCanceled]]) =>
           !isCanceled ?
@@ -289,9 +289,9 @@ export class SearchEffects {
     switchMap(
       (params) =>
         this.asfApiService.query<any[]>(params).pipe(
-        withLatestFrom(combineLatest(
+        withLatestFrom(combineLatest([
           this.store$.select(getSearchType),
-          this.store$.select(getIsCanceled)
+          this.store$.select(getIsCanceled)]
         )),
         map(([response, [searchType, isCanceled]]) => {
           const files = this.productService.fromResponse(response)

--- a/src/app/store/user/user.effect.ts
+++ b/src/app/store/user/user.effect.ts
@@ -27,9 +27,9 @@ export class UserEffects {
   public saveUserProfile = createEffect(() => this.actions$.pipe(
     ofType<userActions.SaveProfile>(userActions.UserActionType.SAVE_PROFILE),
     withLatestFrom(
-      combineLatest(
+      combineLatest([
         this.store$.select(userReducer.getUserAuth),
-        this.store$.select(userReducer.getUserProfile)
+        this.store$.select(userReducer.getUserProfile)]
       )
     ),
     switchMap(
@@ -62,9 +62,9 @@ export class UserEffects {
   public saveSavedSearches = createEffect(() => this.actions$.pipe(
     ofType<userActions.SaveSearches>(userActions.UserActionType.SAVE_SEARCHES),
     withLatestFrom(
-      combineLatest(
+      combineLatest([
         this.store$.select(userReducer.getUserAuth),
-        this.store$.select(userReducer.getSavedSearches)
+        this.store$.select(userReducer.getSavedSearches)]
       )
     ),
     switchMap(
@@ -76,9 +76,9 @@ export class UserEffects {
   public saveSavedFilters = createEffect(() => this.actions$.pipe(
     ofType<userActions.SaveFilters>(userActions.UserActionType.SAVE_FILTERS),
     withLatestFrom(
-      combineLatest(
+      combineLatest([
         this.store$.select(userReducer.getUserAuth),
-        this.store$.select(userReducer.getSavedFilters)
+        this.store$.select(userReducer.getSavedFilters)]
       )
     ),
     switchMap(
@@ -90,9 +90,9 @@ export class UserEffects {
   public saveSearchHistory = createEffect(() => this.actions$.pipe(
     ofType<userActions.SaveSearches>(userActions.UserActionType.SAVE_SEARCH_HISTORY),
     withLatestFrom(
-      combineLatest(
+      combineLatest([
         this.store$.select(userReducer.getUserAuth),
-        this.store$.select(userReducer.getSearchHistory)
+        this.store$.select(userReducer.getSearchHistory)]
       )
     ),
     switchMap(


### PR DESCRIPTION
# Description
 - Minimizes SBAS load after data fetch
 - Gets rid of freezes when clicking on SBAS pairs or adjusting filters
 - Switches combineLatest to use the non-deprecated array-based method


There were two major parts to the cause of SBAS load times being high.

1) The pair$() observable function was making a new observable when called. This meant that when a component wanted access to pairs it was making a new observable to subscribe to. Since it was a completely different observable we didn't have the ability to have it share data amongst all components and it was making new data 12 times with the expensive makePairs() function.

2) Selector functions inherently don't do well with arrays and objects. They use equality operators to check if they should emit the new value and since js checks by reference id for arrays it was always saying that it was entirely new. This is fixed by writing our own equality operator.


An estimate is about a 10-20x improvement in load times and interaction times, with previous timing coming in at about 5-10 seconds on load and the current load time being 0.5 seconds. Will grab some actual stats at a later time

# Actual stats:
Testing with S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C which is a decent size SBAS result with 457 pairs and 317 scenes. The time is measured in the time that the results panel opens up (when results are received from SearchAPI) to the time it takes for the first scene to load in on the sidebar. 

 - refactored SBAS: 849.968017578125 ms (0.8 seconds)
 - previous SBAS: 2939.167236328125 ms (2.9 seconds)

**3.5x** improvement

Trying with a burst product S1_043816_IW1_20230529T033503_VV_75FC-BURST with 639 pairs and 409 scenes

 - [refactored SBAS](https://search-tyler.asf.alaska.edu/#/?zoom=3.000&center=-97.494,39.673&searchType=SBAS%20Search&master=S1_043816_IW1_20230529T033503_VV_75FC-BURST&resultsLoaded=true&granule=S1_043816_IW1_20141019T033414_VV_35FD-BURST&selectedPair=S1_043816_IW1_20141019T033414_VV_35FD-BURST,S1_043816_IW1_20141031T033414_VV_06A3-BURST&perp=300to&temporal=1to12): 1092.910888671875 ms (1.1 seconds)
 - [previous SBAS](https://search.asf.alaska.edu/#/?zoom=3.000&center=-97.494,39.673&searchType=SBAS%20Search&master=S1_043816_IW1_20230529T033503_VV_75FC-BURST&resultsLoaded=true&granule=S1_043816_IW1_20141019T033414_VV_35FD-BURST&selectedPair=S1_043816_IW1_20141019T033414_VV_35FD-BURST,S1_043816_IW1_20141031T033414_VV_06A3-BURST&perp=300to&temporal=1to12): 12924.580322265625 ms (13 seconds)

**11.8x** improvement

This improvement should scale and end up being many times faster for searches with more pairs.
## Extra
~~It looks like there is still one miscellaneous call on startup, pending that will switch this from a draft PR.~~ This looks like it might require a more intensive rework of selectors, saving for a later time