### PR TITLE
Opera S1 Burst Product Types

### DIFF
--- a/src/app/models/cmr-product.model.ts
+++ b/src/app/models/cmr-product.model.ts
@@ -57,6 +57,9 @@ export interface CMRProductMetadata {
   // SLC BURST
   burst: SLCBurstMetadata | null;
 
+  // OPERA-S1
+  opera: OperaS1Metadata | null;
+
   fileName: string | null;
   job: Hyp3Job | null;
 
@@ -73,6 +76,10 @@ export interface SLCBurstMetadata {
   azimuthAnxTime: string;
   samplesPerBurst: number;
   subswath: string;
+}
+
+export interface OperaS1Metadata {
+  operaBurstID: string;
 }
 
 export enum FlightDirection {

--- a/src/app/models/datasets/opera_s1.ts
+++ b/src/app/models/datasets/opera_s1.ts
@@ -26,7 +26,16 @@ export const opera_s1 = {
   productTypes: [
     {
       apiValue: 'RTC',
-      displayName: 'OPERA RTC (RTC)'
+      displayName: 'L2 Radiometric Terrain Corrected (RTC)'
+    }, {
+      apiValue: 'CSLC',
+      displayName: 'L2 Co-registered Single Look Complex (CSLC)'
+    }, {
+        apiValue: 'RTC-STATIC',
+        displayName: 'L2 Radiometric Terrain Corrected Static Layer (RTC-STATIC)'
+    }, {
+        apiValue: 'CSLC-STATIC',
+        displayName: 'L2 Co-registered Single Look Complex Static Layer (CSLC-STATIC)'
     }
   ],
   beamModes: [

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -86,6 +86,7 @@ export class ProductService {
       job: null,
       fileName: null,
       burst: g.s1b ? g.s1b : null,
+      opera: g.s1o ? g.s10 : null,
       pgeVersion: g.pge !== null ? parseFloat(g.pge) : null
     })
 


### PR DESCRIPTION
Adds the following product types as searchable product types:
- L2 Radiometric Terrain Corrected (RTC)
- L2 Radiometric Terrain Corrected Static Layer (RTC-STATIC)
- L2 Co-registered Single Look Complex (CSLC)
- L2 Co-registered Single Look Complex Static Layer (CSLC-STATIC)

Also adds metadata entry for forthcoming `operaBurstID` property