### PR TITLE
DS5349 - Menu issue in the drawing toolbar for AOI on SMALL desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Add the following line via the methods below to set up local.asf.alaska.edu to p
 | Windows | Modify c:\windows\system32\drivers\etc\hosts as Administrator |
 ```
 ng serve --port 4444 --host local.asf.alaska.edu
+ng serve --port 4445 --ssl true --host local.asf.alaska.edu
 ```
 
 ### Setting up HTTPS

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -48,9 +48,9 @@ $config: mat.define-legacy-typography-config();
   height: auto;
   position: fixed;
   top: 100px;
-  z-index: 1;
+  z-index: 2;
   margin: 0;
-  padding: 3px 16px 16px;
+  padding: 3px 16px 25px;
 }
 
 .breadcrumb {

--- a/src/app/components/shared/aoi-options/draw-selector/draw-selector.component.html
+++ b/src/app/components/shared/aoi-options/draw-selector/draw-selector.component.html
@@ -72,6 +72,7 @@
   <button mat-menu-item
     *ngIf="breakpoint !== breakpoints.MOBILE"
     (click)="onImportSelected()"
+    [disabled]="breakpoint <= breakpoints.SMALL"
     class="control-mat-button-toggle">
     <mat-icon class="interaction-icon">upload</mat-icon>
     {{'UPLOAD_GEOSPATIAL_FILE' | translate}}


### PR DESCRIPTION
I disabled the menu option when the AOI input wasn’t displayed in the header. I think maintaining the menu options is a smoother approach. I also increased the z-index of the AOI modal displays about the little triangles in the menu bar. I also added a little more white space at the bottom of the model.

