### PR TITLE
hides calval dataset toggle

### DIFF
--- a/src/app/components/shared/selectors/other-selector/other-selector.component.html
+++ b/src/app/components/shared/selectors/other-selector/other-selector.component.html
@@ -103,5 +103,5 @@
     </mat-hint> -->
   </mat-form-field>
 
-  <app-opera-calibration-data-selector *ngIf="dataset.id === 'OPERA-S1'"></app-opera-calibration-data-selector>
+  <!-- <app-opera-calibration-data-selector *ngIf="dataset.id === 'OPERA-S1'"></app-opera-calibration-data-selector> -->
 </div>

--- a/src/app/services/search-params.service.ts
+++ b/src/app/services/search-params.service.ts
@@ -59,12 +59,12 @@ export class SearchParamsService {
     )
   );
 
-  private operaCalibrationParam$ = this.store$.select(filterStore.getUseCalibrationData).pipe(
-    withLatestFrom(this.store$.select(filterStore.getSelectedDatasetId)),
-    map(([useCalibrationData, dataset]) =>
-      dataset === models.opera_s1.id && useCalibrationData ?
-      ({dataset: models.opera_s1.calibrationDatasets}) : ({}))
-  )
+  // private operaCalibrationParam$ = this.store$.select(filterStore.getUseCalibrationData).pipe(
+  //   withLatestFrom(this.store$.select(filterStore.getSelectedDatasetId)),
+  //   map(([useCalibrationData, dataset]) =>
+  //     dataset === models.opera_s1.id && useCalibrationData ?
+  //     ({dataset: models.opera_s1.calibrationDatasets}) : ({}))
+  // )
 
   private groupID$ = this.store$.select(filterStore.getGroupID).pipe(
     map(groupid => ({
@@ -214,7 +214,7 @@ export class SearchParamsService {
     this.missionParam$,
     this.burstParams$,
     this.operaBurstParams$,
-    this.operaCalibrationParam$,
+    // this.operaCalibrationParam$,
     this.groupID$]
   ).pipe(
     map((params: any[]) => params


### PR DESCRIPTION
- Calval Dataset Toggle No Longer available on OPERA-S1 Dataset filters panel
-  disables logic, does not remove (possible re-use with NISAR)