### PR TITLE
Load unknown hyp3 job types

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -265,6 +265,7 @@ export class AppComponent implements OnInit, OnDestroy, AfterViewInit {
         profile => {
           if (profile.hyp3BackendUrl) {
             this.hyp3Service.setApiUrl(profile.hyp3BackendUrl);
+            this.store$.dispatch(new searchStore.ClearSearch());
           }
 
           this.store$.dispatch(new hyp3Store.LoadCosts());

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.html
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.html
@@ -122,7 +122,7 @@
               </app-scene-metadata>
             </details>
             <div *ngIf="searchType === searchTypes.CUSTOM_PRODUCTS">
-              <div *ngIf="scene.metadata.job.job_parameters.scenes.length > 1">
+              <div *ngIf="scene.metadata.job.job_parameters?.scenes?.length > 1">
                 <hr />
                 <span class="detail-card-header">
                   <b>{{ scene.metadata.job.job_parameters.scenes[1].name }}</b>

--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.component.html
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.component.html
@@ -89,6 +89,15 @@
     <b>{{ param.name }}:</b> {{ param.val }}
   </div>
 
+  <div *ngIf="product.metadata.job && product.metadata.job.job_id" matListItemLine>
+    <b>{{'JOB_ID' | translate}} </b>
+
+    <app-copy-to-clipboard
+      prompt="{{ 'COPY_JOB_ID' | translate }}"
+      [value]="product.metadata.job.job_id">
+    </app-copy-to-clipboard>
+  </div>
+
   <app-download-file-button [attr.id]="'scene_' + product.id" [product]="product"
     (productDownloaded)="prodDownloaded($event)" [disabled]="isExpired(product.metadata.job)" matListItemMeta>
   </app-download-file-button>

--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.component.ts
@@ -54,7 +54,7 @@ export class SceneFileComponent implements OnInit, OnDestroy {
     this.subs.add(
         of(this.product).pipe(
           filter(prod => !!prod.metadata)
-        ).subscribe( prod => {
+        ).subscribe(prod => {
           if (!prod.metadata.job) {
             this.paramsList = [];
           } else {

--- a/src/app/components/results-menu/scenes-list/scene/scene.component.html
+++ b/src/app/components/results-menu/scenes-list/scene/scene.component.html
@@ -30,7 +30,7 @@
            class="bold" matLine>
 
         <app-file-name
-          [name]="(scene.metadata.fileName || scene.name)"
+          [name]="(scene.metadata.fileName || scene.name || scene.metadata.job.job_id)"
           [dataset]="scene.dataset"
           [searchType]="searchType">
         </app-file-name>
@@ -53,9 +53,10 @@
     <div class="date-time" matLine>
       <ng-container *ngIf="scene.metadata.job">
         {{ scene.metadata.job.job_type }}
-        <br *ngIf="breakpoint === breakpoints.MOBILE && searchType === SearchTypes.CUSTOM_PRODUCTS"> -
+        <br *ngIf="breakpoint === breakpoints.MOBILE && searchType === SearchTypes.CUSTOM_PRODUCTS">
       </ng-container>
       <ng-container *ngIf="!scene.isDummyProduct">
+          -
         <ng-container *ngIf="
           breakpoint > breakpoints.MOBILE &&
           searchType !== SearchTypes.BASELINE &&
@@ -79,7 +80,6 @@
           {{ scene.metadata.date| shortDate }}
         </ng-container>
       </ng-container>
-      <span *ngIf="scene.isDummyProduct">Loading...</span>
     </div>
   </div>
 

--- a/src/app/components/shared/hyp3-job-status-badge/hyp3-job-status-badge.component.html
+++ b/src/app/components/shared/hyp3-job-status-badge/hyp3-job-status-badge.component.html
@@ -1,5 +1,7 @@
-  @if(job.job_parameters.scenes[0].isDummyProduct) {
-    <mat-chip color="primary">Loading...</mat-chip>
+  @if(!!job.job_parameters.scenes) {
+    @if (job.job_parameters.scenes[0].isDummyProduct) {
+      <mat-chip color="primary">Loading...</mat-chip>
+    }
   } @else {
 
     @if(isExpired(job) && !isFileDetails) {

--- a/src/app/services/on-demand.service.ts
+++ b/src/app/services/on-demand.service.ts
@@ -13,11 +13,33 @@ export class OnDemandService {
     const jobType = models.hyp3JobTypes[metadata.job.job_type];
     const allOptions = !!jobType ? jobType.options : models.hyp3JobOptionsOrdered;
 
-    return allOptions
+    const addedOptions = new Set(['granules', 'scenes']);
+
+    const knownOptions = allOptions
       .filter(option => metadata.job.job_parameters[option.apiName])
       .map(option => {
+        addedOptions.add(option.apiName);
+
         return {name: option.name, val: metadata.job.job_parameters[option.apiName]};
       });
+
+    const unknownOptions = Object.entries(metadata.job.job_parameters)
+      .filter(([param, _]) => !addedOptions.has(param))
+      .map(([param, val]) => {
+        const name = this.formatJobParamName(param);
+        return ({name, val});
+    });
+
+    return [...knownOptions, ...unknownOptions];
   }
 
+  private formatJobParamName(apiName: string): string {
+  return apiName.toLowerCase()
+    .replaceAll('_', ' ')
+    .replaceAll('dem', 'DEM')
+    .replaceAll('rgb', 'RGB')
+    .split(' ')
+    .map((s) => s.charAt(0).toUpperCase() + s.substring(1))
+    .join(' ');
+  }
 }

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -177,6 +177,9 @@ export class SearchEffects {
 
           return names.concat(gNames);
         } else {
+          if (prod.name === '') {
+            return names;
+          }
           return names.push(prod.name);
         }
       }, []);
@@ -456,18 +459,24 @@ export class SearchEffects {
 
   private hyp3JobToProducts(jobs, products) {
     const virtualProducts = jobs
-    .filter(job => products[job.job_parameters.granules[0]])
     .map(job => {
-      const product = products[job.job_parameters.granules[0]];
-      const jobFile = !!job.files ?
-        job.files[0] :
-        { size: -1, url: '', filename: product.name };
+      let product;
 
-      const scene_keys = job.job_parameters.granules;
-      job.job_parameters.scenes = [];
-      for (const scene_key of scene_keys) {
-        job.job_parameters.scenes.push(products[scene_key]);
+      if (job.job_parameters.granules) {
+        product = products[job.job_parameters.granules[0]];
+        const scene_keys = job.job_parameters.granules;
+
+        job.job_parameters.scenes = [];
+        for (const scene_key of scene_keys) {
+          job.job_parameters.scenes.push(products[scene_key]);
+        }
+      } else {
+        product = this.dummyProduct();
       }
+
+      const dummyJobFile = { size: -1, url: '', filename: product.name };
+      const jobFile = !!job.files && !!job.files[0] ? job.files[0] : dummyJobFile;
+
 
       const jobProduct = {
         ...product,


### PR DESCRIPTION
Allow vertex to handle and show unknown hyp3 jobs. This makes vertex much more useful for custom hyp3 deployments since most are to run different job types.