### PR TITLE
fix users with trouble loading on demand results

### DIFF
--- a/src/app/store/scenes/scenes.reducer.ts
+++ b/src/app/store/scenes/scenes.reducer.ts
@@ -168,7 +168,7 @@ export function scenesReducer(state = initState, action: ScenesActions): ScenesS
               ...jobProduct.metadata.job?.job_parameters,
             }
           };
-          const jobFile = !!job.files ?
+          const jobFile = job.files?.length > 0 ?
             job.files[0] :
             { size: -1, url: '', filename: product.name };
 

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -456,10 +456,11 @@ export class SearchEffects {
 
   private hyp3JobToProducts(jobs, products) {
     const virtualProducts = jobs
+    .filter(job => job.job_type in models.hyp3JobTypes)
     .filter(job => products[job.job_parameters.granules[0]])
     .map(job => {
       const product = products[job.job_parameters.granules[0]];
-      const jobFile = !!job.files ?
+      const jobFile = job.files?.length > 0 ?
         job.files[0] :
         { size: -1, url: '', filename: product.name };
 


### PR DESCRIPTION
This is a hotfix for 3 users who are having trouble loading hyp3 jobs

- Filter out job types that are unknown to vertex (to fix ARIA_S1_GUNW breaking things)
- Check that job `files` array isn't empty before pulling out the first job file
 