### PR TITLE
Fix: broken links in dataset selector

### DIFF
--- a/src/app/components/shared/selectors/dataset-selector/dataset-selector.component.html
+++ b/src/app/components/shared/selectors/dataset-selector/dataset-selector.component.html
@@ -36,10 +36,7 @@
                     {{ dataset.platformDesc | translate }}
                   </div>
                   <mat-card-actions (click)="onOpenDocs($event, dataset.id)">
-                    <app-docs-modal class="info-text"
-                                    text="{{ 'MORE_INFO' | translate }}"
-                                    url="{{ dataset.infoUrl }}">
-                    </app-docs-modal>
+                    <a class="info-text blue-link" [href]="dataset.infoUrl" target="_blank">{{ 'MORE_INFO' | translate }}</a>
                   </mat-card-actions>
                 </div>
                 <div class="dataset-aside--layout menu-item-aside">


### PR DESCRIPTION
### Issue
Some 'more info' links in datasets selector are broken when they are opened in using an iframe. I think some nasa sites don't play nice with iframes.

### Solution
Change 'more info' links to be regular links that open in new tab