### PR TITLE
Removed ASF Tag Manager

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,15 +9,6 @@
   })(window,document,'script','dataLayer','GTM-WNP7MLF');</script>
   <!-- End NASA Google Tag Manager -->
 
-  <!-- ASF Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-5KZ8WLF');</script>
-  <!-- End ASF Google Tag Manager -->
-
-
   <meta charset="utf-8">
   <title>ASF Data Search</title>
   <base href="/">


### PR DESCRIPTION
Removed the snippet in the site header that included the ASF Tag Manager. The NASA Tag Manager snippet remains.