### PR TITLE
v2.13.0 (AKA v2.12.0 take 2)

### DIFF
--- a/.github/workflows/prod-request-merged.yml
+++ b/.github/workflows/prod-request-merged.yml
@@ -31,7 +31,7 @@ jobs:
         (${{ contains(github.event.pull_request.labels.*.name, 'minor') }} && echo "version_type=minor" >> $GITHUB_ENV) || true
         (${{ contains(github.event.pull_request.labels.*.name, 'major') }} && echo "version_type=major" >> $GITHUB_ENV) || true
     - name: Create a Release
-      uses: zendesk/action-create-release@v1
+      uses: zendesk/action-create-release@v3
       env:
         # NOT built in token, so this can trigger other actions:
         GITHUB_TOKEN: ${{ secrets.DISCO_GITHUB_MACHINE_USER }}

--- a/src/app/components/map/displacement-layers/displacement-layers.component.html
+++ b/src/app/components/map/displacement-layers/displacement-layers.component.html
@@ -20,7 +20,7 @@
     </div>
 
     @if (this.displacementOverview === DispLayerTypes.VELOCITY) {
-      <div style="margin-top: -5px; height: 25px;" >
+      <div style="margin-top: -5px; height: 25px; margin-bottom: 5px;" >
         <app-map-legend
           style="display: inline-block; margin-top: -5px;"
           [min]="this.mapService.displacementRange?.range[0]"
@@ -43,31 +43,6 @@
           </mat-slider>
         </div>
 
-      </div>
-    }
-
-    <mat-checkbox #priorityRollout class="rollout-checkbox"
-    (change)="onUpdatePriority($event.checked)"
-    [checked]="priorityEnabled">
-      <div class="selector-text">
-        {{ 'ROLLOUT' | translate}}
-      </div>
-    </mat-checkbox>
-    <div class="rollout-help-icon">
-      <app-docs-modal custStyle="color: #ffffffb3; cursor: pointer; text-decoration: underline;"
-                      text=""
-                      icon="help_outline"
-                      url="https://docs.asf.alaska.edu/vertex/displacement/#rollout"
-      >
-      </app-docs-modal>
-    </div>
-
-
-    @if (priorityEnabled) {
-      <div class="priority-legend">
-        <div class="priority-box first-priority">1st</div>
-        <div class="priority-box second-priority">2nd</div>
-        <div class="priority-box third-priority">3rd</div>
       </div>
     }
 

--- a/src/app/components/map/displacement-layers/displacement-layers.component.scss
+++ b/src/app/components/map/displacement-layers/displacement-layers.component.scss
@@ -70,47 +70,6 @@
   justify-content: space-between;
 }
 
-.rollout-checkbox {
-  margin: 4px 0;
-  position: relative;
-}
-
-.priority-legend {
-  display: inline-flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  //margin: 0 5px 5px;
-  margin-top: -5px;
-  margin-bottom: 7px;
-  margin-left: 40px;
-  width: 170px;
-  height: 20px;
-  padding: 0;
-  border-radius: 4px;
-}
-
-.priority-box {
-  flex: 1;
-  margin: 0;
-  text-align: center;
-  vertical-align: middle;
-}
-
-.first-priority {
-  background-color: rgba(127, 206, 255, 0.8);
-}
-
-.second-priority {
-  color: white;
-  background-color: rgba(45, 128, 179, 0.7);
-}
-
-.third-priority {
-  color: white;
-  background-color: rgba(0, 64, 103, 0.6);
-}
-
 .velocity-help-icon {
   position: absolute;
   margin-top: 9px;

--- a/src/app/components/map/displacement-layers/displacement-layers.component.ts
+++ b/src/app/components/map/displacement-layers/displacement-layers.component.ts
@@ -25,7 +25,6 @@ export class DisplacementLayersComponent implements OnInit, OnDestroy {
   public displacementOverview: models.DisplacementLayerTypes | null = null;
   public cumulativeDisplacementSelectionEnabled: boolean = false;
   public DispLayerTypes = models.DisplacementLayerTypes;
-  public priorityEnabled = false;
   private subs = new SubSink();
   public velocityOverlayOpacity: number;
 
@@ -63,28 +62,10 @@ export class DisplacementLayersComponent implements OnInit, OnDestroy {
         } else {
           this.setDisplacementLayer(this.flightDir, models.DisplacementLayerTypes.VELOCITY);
         }
-        if (this.priorityCheckbox.checked) {
-          this.mapService.disablePriority()
-          this.onUpdatePriority(this.priorityCheckbox.checked)
-        }
       }
       )
     )
-    this.subs.add(
-      this.mapService.priorityEnabled$.subscribe(t => {
-        this.priorityEnabled = t !== null;
-      })
-    )
 
-  }
-
-  public onUpdatePriority(isChecked: boolean): void {
-    if (isChecked) {
-      this.mapService.enablePriority(this.flightDir);
-    }
-    else {
-      this.mapService.disablePriority();
-    }
   }
 
   public onUpdateLayerType(layerType: models.DisplacementLayerTypes): void {
@@ -141,6 +122,5 @@ public onToggleDisplacementLayerDisplay(checked: boolean): void {
   ngOnDestroy() {
     this.subs.unsubscribe();
     this.mapService.clearDisplacementOverview();
-    this.mapService.disablePriority();
   }
 }

--- a/src/app/components/map/map-controls/layer-selector/layer-selector.component.ts
+++ b/src/app/components/map/map-controls/layer-selector/layer-selector.component.ts
@@ -7,11 +7,9 @@ import { AppState } from '@store';
 import * as mapStore from '@store/map';
 
 import * as models from '@models';
-import * as filtersStore from '@store/filters';
 import * as searchStore from '@store/search';
 
 import { MapService, ScreenSizeService } from '@services';
-import { map } from 'rxjs';
 
 @Component({
   selector: 'app-layer-selector',
@@ -41,7 +39,6 @@ export class LayerSelectorComponent implements OnInit, OnDestroy {
   public breakpoint: models.Breakpoints;
   public breakpoints = models.Breakpoints;
   private coherenceLayerOpacity: number;
-  private flightDir: models.FlightDirection = models.FlightDirection.ASCENDING;
   public priorityEnabled = false;
 
 
@@ -90,14 +87,6 @@ export class LayerSelectorComponent implements OnInit, OnDestroy {
         }
       )
     )
-
-    this.subs.add(
-      this.store$.select(filtersStore.getFlightDirections).pipe(
-        map(flightDirs => flightDirs[0] ?? models.FlightDirection.ASCENDING)
-      ).subscribe(
-        flightDir => this.flightDir = flightDir
-      )
-    )
   }
 
   public onNewLayerType(layerType: models.MapLayerTypes): void {
@@ -137,16 +126,6 @@ export class LayerSelectorComponent implements OnInit, OnDestroy {
     }
 
     this.clearCoherenceLayer();
-  }
-  public togglePriority(): void {
-    if(!this.priorityEnabled) {
-      this.mapService.enablePriority(this.flightDir);
-      this.priorityEnabled = true;
-    }
-    else {
-      this.priorityEnabled = false;
-      this.mapService.disablePriority();
-    }
   }
 
   public onToggleOverviewMap(isOpen: boolean): void {

--- a/src/app/services/map/map.service.ts
+++ b/src/app/services/map/map.service.ts
@@ -1141,54 +1141,6 @@ export class MapService implements OnDestroy {
     this.hasCoherenceLayer$.next(null);
   }
 
-  public enablePriority(flight_dir: models.FlightDirection): void {
-    const source = new VectorSource({
-      url: `/assets/priority_rollout_${flight_dir}.geojson`,
-      format: new GeoJSON({})
-    },
-    )
-    this.priorityEnabled$.next(flight_dir);
-
-    const colorTable = [
-      'rgba(174, 174, 174, 0.6)',
-      'rgba(127, 206, 255, 0.8)',
-      'rgba(45, 128, 179, 0.7)',
-      'rgba(0, 64, 103, 0.6)',
-    ]
-    this.priorityOverview.setSource(source);
-    this.priorityOverview.setStyle(function (feature, _resolution) {
-      const test = feature.getProperties();
-      const priority = +test['priority'];
-      let color = '#FF0000';
-      if (priority === 1) {
-        color = colorTable[1];
-      } else if (priority === 2) {
-        color = colorTable[2];
-      } else if (priority === 3) {
-        color = colorTable[3];
-      } else {
-        color = colorTable[0]
-      }
-      return new Style({
-        fill: new Fill({
-          color: color
-        }),
-        stroke: new Stroke({
-          color: 'black',
-        })
-      });
-    })
-  }
-
-  public disablePriority(): void {
-    this.priorityOverview.setSource(null);
-    this.priorityEnabled$.next(null);
-  }
-
-  public isPriorityEnabled(): boolean {
-    return !!this.priorityEnabled$.value
-  }
-
   public createBrowseRasterCanvas(scenes: models.CMRProduct[]) {
     const scenesWithBrowse = scenes.filter(scene => scene.browses?.length > 0).slice(0, 10);
 

--- a/src/app/services/url-state.service.ts
+++ b/src/app/services/url-state.service.ts
@@ -353,13 +353,6 @@ export class UrlStateService {
         loader: this.loadDispOverview
       },
       {
-        name: 'isPriorityEnabled',
-        source: this.mapService.priorityEnabled$.pipe(
-          map(isPriorityEnabled => ({isPriorityEnabled})),
-        ),
-        loader: this.loadDispPriority
-      },
-      {
         name: 'isShowLinesEnabled',
         source: this.store$.select(chartsStore.getShowLines).pipe(
           map(isShowLinesEnabled => ({isShowLinesEnabled})),
@@ -1036,12 +1029,6 @@ export class UrlStateService {
   }
   private loadDispOverview = (dispOverview) => {
     this.mapService.setDisplacementType(dispOverview);
-    return;
-  }
-  private loadDispPriority = (isDispPriorityEnabled) => {
-    if(isDispPriorityEnabled) {
-      this.mapService.enablePriority(isDispPriorityEnabled);
-    }
     return;
   }
   private loadDispShowLines = (isShowLinesEnabled) => {


### PR DESCRIPTION
### Removed
- Removed OPERA-DISP Priority Rollout Map

### Fixed
- Update zendesk/action-create-release to v3

# Previously added in v2.12.0
### Features
- Adds ARIA GUNW on demand functionality
  - Frame map selection
  - SBAS with dataset frame selection
  - On Demand queue/results list 
 - Export dialog refinement
 - NISAR loading animation
 - OPERA-S1 dataset TROPO-ZENITH products now searchable
 
 ### Fixes
 - OPERA additional url parsing
 - URL param loading cleared filters under specific conditions
 - Empty CSV in SBAS/Baseline
 - General UI improvements