### PR TITLE
v2.13.2

### DIFF
--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
@@ -563,24 +563,28 @@
               }}{{ downloadableProds.length === 1 ? '' : 's' }}
             </button>
 
+            @let currentDatasetID = currentDatasetID$ | async;
+            @if ( searchType === SearchTypes.DATASET
+                && (
+                    currentDatasetID === 'OPERA-S1'
+                    || currentDatasetID === 'NISAR'
+                    || currentDatasetID === 'SEASAT'
+                    )
+                ) {
             <button
               mat-menu-item
-              *ngIf="
-                searchType === SearchTypes.DATASET &&
-                ((currentDatasetID$ | async) === 'OPERA-S1' ||
-                  (currentDatasetID$ | async) === 'NISAR')
-              "
               [matMenuTriggerFor]="addAllProductsOfType"
               [matMenuTriggerData]="{
                 productData: (productCountByType$ | async),
               }"
             >
               {{
-                (currentDatasetID$ | async) === 'NISAR'
+                currentDatasetID === 'NISAR'
                   ? ('ADD_BY_FILE_TYPE' | translate)
                   : ('ADD_BY_PRODUCT_TYPE' | translate)
               }}
             </button>
+        }
           </mat-menu>
 
           <mat-menu #addAllProductsOfType>

--- a/src/app/models/cmr-product.model.ts
+++ b/src/app/models/cmr-product.model.ts
@@ -96,6 +96,7 @@ export interface SLCBurstMetadata {
 export interface OperaS1Metadata {
   operaBurstID: string;
   additionalUrls: string[];
+  s3Urls: string[];
   validityStartDate?: moment.Moment | null;
 }
 

--- a/src/app/models/cmr-product.model.ts
+++ b/src/app/models/cmr-product.model.ts
@@ -72,7 +72,10 @@ export interface CMRProductMetadata {
 
   // BURST XML, OPERA-S1, NISAR
   subproducts: any[];
+  additionalUrls?: string[] | null;
   s3URI?: string;
+  s3Urls?: string[] | null;
+  fileSizes?: {} | null;
   parentID: string;
 
   // ARIA S1 GUNW

--- a/src/app/models/dataset.model.ts
+++ b/src/app/models/dataset.model.ts
@@ -33,6 +33,7 @@ export interface Dataset {
     ascending: string;
     descending: string;
   };
+  productTypeDisplays?: {[index: string]: string};
 }
 
 export enum MissionDataset {

--- a/src/app/models/datasets/nisar.ts
+++ b/src/app/models/datasets/nisar.ts
@@ -275,6 +275,20 @@ export const nisar = {
   //   ],
   platformDesc: 'NISAR_DESC',
   platformIcon: '/assets/icons/satellite_alt_black_48dp.svg',
+
+  productTypeDisplays: {
+    yaml: 'Runconfig YAML',
+    kml: 'Footprint KML',
+    png: 'Browse Image PNG',
+    csv: 'QA Summary CSV',
+    h5: 'HDF5',
+    xml: 'ISO Metadata XML',
+    json: 'Metadata JSON',
+    pdf: 'QA Report PDF',
+    log: 'Log File',
+    qa: 'QA Statistics HDF5',
+    bin: 'Bin File',
+  }
 };
 
 export const L1L2BrowseCollectionMapping = {

--- a/src/app/models/datasets/opera_s1.ts
+++ b/src/app/models/datasets/opera_s1.ts
@@ -66,4 +66,19 @@ export const opera_s1 = {
   ],
   platformDesc: 'OPERA_S1_DESC',
   platformIcon: '/assets/icons/satellite_alt_black_48dp.svg',
+  productTypeDisplays: {
+    hh: 'HH GeoTIFF',
+    hv: 'HV GeoTIFF',
+    vv: 'VV GeoTIFF',
+    vh: 'VH GeoTIFF',
+    mask: 'Mask GeoTIFF',
+    nc: 'Netcdf File',
+    h5: 'HDF5',
+    xml: 'Metadata XML',
+    rtc_anf_gamma0_to_sigma0: 'RTC Gamma to Sigma GeoTIFF',
+    number_of_looks: '# of Looks GeoTIFF',
+    incidence_angle: 'Incidence Angle GeoTIFF',
+    rtc_anf_gamma0_to_beta0: 'RTC Gamm to Beta GeoTIFF',
+    local_incidence_angle: 'Local Incidence Angle GeoTIFF',
+  }
 };

--- a/src/app/models/datasets/seasat.ts
+++ b/src/app/models/datasets/seasat.ts
@@ -25,7 +25,7 @@ export const seasat = {
     name: 'NASA',
     url: 'https://www.nasa.gov/',
   },
-  infoUrl: 'https://asf.alaska.edu/datasets/daac/seasat/',
+  infoUrl: 'https://www.earthdata.nasa.gov/data/catalog/asf-seasat-l1-sar-1',
   citationUrl:
     'https://asf.alaska.edu/data-sets/sar-data-sets/seasat/seasat-how-to-cite/',
   productTypes: [

--- a/src/app/models/datasets/seasat.ts
+++ b/src/app/models/datasets/seasat.ts
@@ -13,6 +13,7 @@ export const seasat = {
     Props.FLIGHT_DIRECTION,
     Props.POLARIZATION,
     Props.ABSOLUTE_ORBIT,
+    Props.USE_BEAM_MODE,
   ],
   apiValue: { dataset: 'SEASAT' },
   date: {
@@ -28,14 +29,6 @@ export const seasat = {
   citationUrl:
     'https://asf.alaska.edu/data-sets/sar-data-sets/seasat/seasat-how-to-cite/',
   productTypes: [
-    {
-      apiValue: 'GEOTIFF',
-      displayName: 'Level One GeoTIFF product',
-    },
-    {
-      apiValue: 'L1',
-      displayName: 'Level One HDF5 Image',
-    },
   ],
   beamModes: ['STD'],
   polarizations: ['HH'],

--- a/src/app/models/datasets/seasat.ts
+++ b/src/app/models/datasets/seasat.ts
@@ -35,4 +35,13 @@ export const seasat = {
   subtypes: [],
   platformDesc: 'SEASAT_DESC',
   platformIcon: '/assets/icons/satellite_alt_black_48dp.svg',
+  productTypeDisplays: {
+    h5: 'Level One HDF5 Image',
+    in: 'Metadata IN',
+    tif: 'Level One GeoTIFF Product',
+    xml: 'ISO Metadata XML',
+    kml: 'Metadata KML',
+    qc_report: 'QC Report',
+    jpg: 'Browse Image JPEG'
+  }
 };

--- a/src/app/services/product.service.spec.ts
+++ b/src/app/services/product.service.spec.ts
@@ -16,34 +16,34 @@ describe('ProductService', () => {
   it('should parse old links correctly', () => {
     const url =
       'https://datapool.asf.alaska.edu/RTC/OPERA-S1/OPERA_L2_RTC-S1_T001-000189-IW2_20211028T180924Z_20250703T015334Z_S1A_30_v1.0_VH.tif';
-    expect(service.urlToProductType(url)).toBe('VH');
+    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('VH');
   });
   it('should parse h5 cumulus link', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L2_RTC-S1/OPERA_L2_RTC-S1_T139-297356-IW2_20250929T054926Z_20251002T213318Z_S1C_30_v1.0/OPERA_L2_RTC-S1_T139-297356-IW2_20250929T054926Z_20251002T213318Z_S1C_30_v1.0_VH.tif';
-    expect(service.urlToProductType(url)).toBe('VH');
+    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('VH');
   });
   it('should parse a base download url', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L2_RTC-S1/OPERA_L2_RTC-S1_T140-299545-IW1_20250929T073003Z_20251003T012020Z_S1C_30_v1.0/OPERA_L2_RTC-S1_T140-299545-IW1_20250929T073003Z_20251003T012020Z_S1C_30_v1.0.h5';
-    expect(service.urlToProductType(url)).toBe('h5');
+    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('h5');
   });
   it('should parse links with more than one word', () => {
     const datapool =
       'https://datapool.asf.alaska.edu/RTC-STATIC/OPERA-S1/OPERA_L2_RTC-S1-STATIC_T144-308004-IW3_20140403_S1A_30_v1.0_number_of_looks.tif';
     const cumulus =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA-S1/OPERA_L2_RTC-S1-STATIC_T144-308004-IW3_20140403_S1A_30_v1.0_number_of_looks.tif';
-    expect(service.urlToProductType(datapool)).toBe('number_of_looks');
-    expect(service.urlToProductType(cumulus)).toBe('number_of_looks');
+    expect(service.urlToProductType(datapool, service.operaProductTypeDisplays)).toBe('number_of_looks');
+    expect(service.urlToProductType(cumulus, service.operaProductTypeDisplays)).toBe('number_of_looks');
   });
   it('should parse xml cumulus link', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L4_TROPO-ZENITH_V1/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0.iso.xml';
-    expect(service.urlToProductType(url)).toBe('xml');
+    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('xml');
   });
   it('should parse netcdf cumulus link', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L4_TROPO-ZENITH_V1/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0.nc';
-    expect(service.urlToProductType(url)).toBe('nc');
+    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('nc');
   });
 });

--- a/src/app/services/product.service.spec.ts
+++ b/src/app/services/product.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ProductService } from './product.service';
+import * as models from '@models';
 
 describe('ProductService', () => {
   let service: ProductService;
@@ -16,44 +17,44 @@ describe('ProductService', () => {
   it('should parse old links correctly', () => {
     const url =
       'https://datapool.asf.alaska.edu/RTC/OPERA-S1/OPERA_L2_RTC-S1_T001-000189-IW2_20211028T180924Z_20250703T015334Z_S1A_30_v1.0_VH.tif';
-    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('VH');
+    expect(service.urlToProductType(url, models.opera_s1.productTypeDisplays)).toBe('VH');
   });
   it('should parse h5 cumulus link', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L2_RTC-S1/OPERA_L2_RTC-S1_T139-297356-IW2_20250929T054926Z_20251002T213318Z_S1C_30_v1.0/OPERA_L2_RTC-S1_T139-297356-IW2_20250929T054926Z_20251002T213318Z_S1C_30_v1.0_VH.tif';
-    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('VH');
+    expect(service.urlToProductType(url, models.opera_s1.productTypeDisplays)).toBe('VH');
   });
   it('should parse a base download url', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L2_RTC-S1/OPERA_L2_RTC-S1_T140-299545-IW1_20250929T073003Z_20251003T012020Z_S1C_30_v1.0/OPERA_L2_RTC-S1_T140-299545-IW1_20250929T073003Z_20251003T012020Z_S1C_30_v1.0.h5';
-    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('h5');
+    expect(service.urlToProductType(url, models.opera_s1.productTypeDisplays)).toBe('h5');
   });
   it('should parse links with more than one word', () => {
     const datapool =
       'https://datapool.asf.alaska.edu/RTC-STATIC/OPERA-S1/OPERA_L2_RTC-S1-STATIC_T144-308004-IW3_20140403_S1A_30_v1.0_number_of_looks.tif';
     const cumulus =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA-S1/OPERA_L2_RTC-S1-STATIC_T144-308004-IW3_20140403_S1A_30_v1.0_number_of_looks.tif';
-    expect(service.urlToProductType(datapool, service.operaProductTypeDisplays)).toBe('number_of_looks');
-    expect(service.urlToProductType(cumulus, service.operaProductTypeDisplays)).toBe('number_of_looks');
+    expect(service.urlToProductType(datapool, models.opera_s1.productTypeDisplays)).toBe('number_of_looks');
+    expect(service.urlToProductType(cumulus, models.opera_s1.productTypeDisplays)).toBe('number_of_looks');
   });
   it('should parse xml cumulus link', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L4_TROPO-ZENITH_V1/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0.iso.xml';
-    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('xml');
+    expect(service.urlToProductType(url, models.opera_s1.productTypeDisplays)).toBe('xml');
   });
   it('should parse netcdf cumulus link', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L4_TROPO-ZENITH_V1/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0.nc';
-    expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('nc');
+    expect(service.urlToProductType(url, models.opera_s1.productTypeDisplays)).toBe('nc');
   });
   it('should parse seasat hdf5 link', () => {
     const url =
       'https://cumulus.asf.earthdatacloud.nasa.gov/SEASAT/SS_01502_STD_F2536/SS_01502_STD_F2536.h5';
-    expect(service.urlToProductType(url, service.seasatProductTypeDisplays)).toBe('h5');
+    expect(service.urlToProductType(url, models.seasat.productTypeDisplays)).toBe('h5');
   });
   it('should parse seasat geotiff s3 link', () => {
     const url =
       'https://cumulus.asf.earhtdatacloud.nasa.gov/SEASAT/SS_01502_STD_F2536/SS_01502_STD_F2536.tif';
-    expect(service.urlToProductType(url, service.seasatProductTypeDisplays)).toBe('tif');
+    expect(service.urlToProductType(url, models.seasat.productTypeDisplays)).toBe('tif');
   });
 });

--- a/src/app/services/product.service.spec.ts
+++ b/src/app/services/product.service.spec.ts
@@ -46,4 +46,14 @@ describe('ProductService', () => {
       'https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L4_TROPO-ZENITH_V1/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0/OPERA_L4_TROPO-ZENITH_20251003T180000Z_20251006T000715Z_HRES_v1.0.nc';
     expect(service.urlToProductType(url, service.operaProductTypeDisplays)).toBe('nc');
   });
+  it('should parse seasat hdf5 link', () => {
+    const url =
+      'https://cumulus.asf.earthdatacloud.nasa.gov/SEASAT/SS_01502_STD_F2536/SS_01502_STD_F2536.h5';
+    expect(service.urlToProductType(url, service.seasatProductTypeDisplays)).toBe('h5');
+  });
+  it('should parse seasat geotiff s3 link', () => {
+    const url =
+      'https://cumulus.asf.earhtdatacloud.nasa.gov/SEASAT/SS_01502_STD_F2536/SS_01502_STD_F2536.tif';
+    expect(service.urlToProductType(url, service.seasatProductTypeDisplays)).toBe('tif');
+  });
 });

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -105,6 +105,9 @@ export class ProductService {
     subproducts: [],
     parentID: null,
     s3URI: null,
+    s3Urls: g.s3u || [],
+    additionalUrls: g.adu || [],
+    fileSizes: isNaN(g.bytes) ? g.s : null,
     ariaVersion: g.ariav ? g.ariav : null,
   });
 
@@ -122,6 +125,9 @@ export class ProductService {
     }
     if (product.dataset === 'NISAR') {
       return this.nisarSubproductsFromScene(product);
+    }
+    if (product.dataset === 'SEASAT 1') {
+        return this.seasatSubproductsFromScene(product);
     }
     return [];
   }
@@ -288,6 +294,112 @@ export class ProductService {
     qa: 'QA Statistics HDF5',
     bin: 'Bin File',
   };
+
+private seasatProductTypeDisplays = {
+    in: 'Metadata IN',
+    tif: 'Level One GeoTIFF Product',
+    xml: 'Metadata xml',
+    kml: 'Metadata kml',
+    qc_report: 'QC Report',
+    jpg: 'Browse Image JPG'
+  };
+private seasatSubproductsFromScene(product: models.CMRProduct) {
+ const products = [];
+    let temp = product.downloadUrl.split('.');
+    let file_extension = temp[temp.length - 1];
+    product.productTypeDisplay = `Level One HDF5 Image`;
+    let fileID = product.downloadUrl.split('/').slice(-1)[0];
+    product.bytes = product.metadata.fileSizes[fileID].bytes
+    const thumbnail_index = product.browses.findIndex((url) =>
+      url.toLowerCase().includes('thumbnail'),
+    );
+    if (thumbnail_index !== -1) {
+      product.thumbnail = product.browses.splice(thumbnail_index, 1)[0];
+    }
+    product.browses = product.browses.filter((url) => !url.includes('low-res'));
+
+    const s3UrlsByProductID = product.metadata.s3Urls.reduce(
+      (prev, curr) => {
+        const subproductFileID = curr.split('/').at(-1);
+
+        prev[subproductFileID] = curr;
+
+        return prev;
+      },
+      {},
+    );
+
+    product.metadata.s3URI = s3UrlsByProductID[product.file] ?? null;
+
+    const browses = [];
+    for (const p of [
+      ...product.metadata.additionalUrls.filter(
+        (url) => url !== product.downloadUrl,
+      ),
+      ...product.browses,
+    ]) {
+      temp = p.split('.');
+      file_extension = temp[temp.length - 1];
+      let productTypeDisplay =
+        this.seasatProductTypeDisplays[file_extension.toLowerCase()] ??
+        'Missing Display';
+      if (productTypeDisplay === 'Missing Display') {
+        if (file_extension.includes('vc')) {
+          productTypeDisplay = file_extension.toUpperCase();
+        } else {
+          console.log(
+            `Missing product type display for file extension "${file_extension}"`,
+          );
+        }
+      }
+      if (productTypeDisplay === 'Browse PNG') {
+        browses.push(p);
+      }
+
+      if (['Log File', 'Metadata JSON'].includes(productTypeDisplay)) {
+        continue;
+      }
+
+      const fileID = p.split('/').slice(-1)[0];
+      const s3Url = s3UrlsByProductID[fileID] ?? null;
+
+      const subproduct = {
+        ...product,
+        downloadUrl: p,
+        productTypeDisplay: productTypeDisplay || p,
+        file: fileID,
+        id: product.id + '-' + file_extension,
+        bytes: product.metadata.fileSizes[fileID]?.bytes ?? 0,
+        browses,
+        thumbnail: null,
+        metadata: {
+          ...product.metadata,
+          productType: product.metadata.productType,
+          parentID: product.id,
+          subproducts: [],
+          s3URI: s3Url,
+        },
+        virtual: true,
+      } as models.CMRProduct;
+      products.push(subproduct);
+    }
+
+    return products.sort((a, b) => {
+      if (
+        a.productTypeDisplay.includes('Metadata') ||
+        a.productTypeDisplay.includes('QA')
+      ) {
+        return 1;
+      } else if (
+        b.productTypeDisplay.includes('Metadata') ||
+        b.productTypeDisplay.includes('QA')
+      ) {
+        return -1;
+      }
+
+      return a.productTypeDisplay < b.productTypeDisplay ? -1 : 1;
+    });
+  }
 
   private nisarSubproductsFromScene(product: models.CMRProduct) {
     const products = [];

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -298,10 +298,10 @@ export class ProductService {
 private seasatProductTypeDisplays = {
     in: 'Metadata IN',
     tif: 'Level One GeoTIFF Product',
-    xml: 'Metadata xml',
-    kml: 'Metadata kml',
+    xml: 'ISO Metadata XML',
+    kml: 'Metadata KML',
     qc_report: 'QC Report',
-    jpg: 'Browse Image JPG'
+    jpg: 'Browse Image JPEG'
   };
 private seasatSubproductsFromScene(product: models.CMRProduct) {
  const products = [];
@@ -356,7 +356,7 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
         browses.push(p);
       }
 
-      if (['Log File', 'Metadata JSON'].includes(productTypeDisplay)) {
+      if (['Metadata IN'].includes(productTypeDisplay)) {
         continue;
       }
 

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -132,7 +132,7 @@ export class ProductService {
     return [];
   }
 
-  public urlToProductType(url) {
+  public urlToProductType(url: string, productTypeDisplay: {[index: string]: string}) {
     const regex = /(_v[0-9]\.[0-9]){1}(\.(\w*)|(_(\w*(_*))*.))*/;
 
     if (url) {
@@ -148,7 +148,7 @@ export class ProductService {
           .pop();
 
         if (
-          !this.operaProductTypeDisplays.hasOwnProperty(
+          !productTypeDisplay.hasOwnProperty(
             file_type?.toLowerCase(),
           )
         ) {
@@ -181,7 +181,7 @@ export class ProductService {
     return p;
   }
 
-  private operaProductTypeDisplays = {
+  public operaProductTypeDisplays = {
     hh: 'HH GeoTIFF',
     hv: 'HV GeoTIFF',
     vv: 'VV GeoTIFF',
@@ -210,7 +210,7 @@ export class ProductService {
     if (['DISP-S1', 'TROPO-ZENITH'].includes(product.metadata.productType)) {
       file_suffix = 'nc';
     } else {
-      file_suffix = this.urlToProductType(product.downloadUrl);
+      file_suffix = this.urlToProductType(product.downloadUrl, this.operaProductTypeDisplays);
     }
 
     product.productTypeDisplay =
@@ -227,7 +227,7 @@ export class ProductService {
     for (const p of product.metadata.opera.additionalUrls.filter(
       (url) => url !== product.downloadUrl,
     )) {
-      file_suffix = this.urlToProductType(p);
+      file_suffix = this.urlToProductType(p, this.operaProductTypeDisplays);
 
       let productTypeDisplay =
         this.operaProductTypeDisplays[file_suffix?.toLowerCase()];
@@ -295,7 +295,8 @@ export class ProductService {
     bin: 'Bin File',
   };
 
-private seasatProductTypeDisplays = {
+public seasatProductTypeDisplays = {
+    h5: 'Level One HDF5 Image',
     in: 'Metadata IN',
     tif: 'Level One GeoTIFF Product',
     xml: 'ISO Metadata XML',
@@ -304,10 +305,9 @@ private seasatProductTypeDisplays = {
     jpg: 'Browse Image JPEG'
   };
 private seasatSubproductsFromScene(product: models.CMRProduct) {
- const products = [];
-    let temp = product.downloadUrl.split('.');
-    let file_extension = temp[temp.length - 1];
-    product.productTypeDisplay = `Level One HDF5 Image`;
+    const products = [];
+    let file_extension = this.urlToProductType(product.downloadUrl, this.seasatProductTypeDisplays)
+    product.productTypeDisplay = this.seasatProductTypeDisplays[file_extension];
     let fileID = product.downloadUrl.split('/').slice(-1)[0];
     product.bytes = product.metadata.fileSizes[fileID].bytes
     const thumbnail_index = product.browses.findIndex((url) =>
@@ -338,22 +338,15 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
       ),
       ...product.browses,
     ]) {
-      temp = p.split('.');
-      file_extension = temp[temp.length - 1];
+      file_extension = this.urlToProductType(p, this.seasatProductTypeDisplays)
+
       let productTypeDisplay =
         this.seasatProductTypeDisplays[file_extension.toLowerCase()] ??
         'Missing Display';
       if (productTypeDisplay === 'Missing Display') {
-        if (file_extension.includes('vc')) {
-          productTypeDisplay = file_extension.toUpperCase();
-        } else {
-          console.log(
-            `Missing product type display for file extension "${file_extension}"`,
-          );
-        }
-      }
-      if (productTypeDisplay === 'Browse PNG') {
-        browses.push(p);
+        console.log(
+        `Missing product type display for file extension "${file_extension}"`,
+        );
       }
 
       if (['Metadata IN'].includes(productTypeDisplay)) {

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -181,22 +181,6 @@ export class ProductService {
     return p;
   }
 
-  public operaProductTypeDisplays = {
-    hh: 'HH GeoTIFF',
-    hv: 'HV GeoTIFF',
-    vv: 'VV GeoTIFF',
-    vh: 'VH GeoTIFF',
-    mask: 'Mask GeoTIFF',
-    nc: 'Netcdf File',
-    h5: 'HDF5',
-    xml: 'Metadata XML',
-    rtc_anf_gamma0_to_sigma0: 'RTC Gamma to Sigma GeoTIFF',
-    number_of_looks: '# of Looks GeoTIFF',
-    incidence_angle: 'Incidence Angle GeoTIFF',
-    rtc_anf_gamma0_to_beta0: 'RTC Gamm to Beta GeoTIFF',
-    local_incidence_angle: 'Local Incidence Angle GeoTIFF',
-  };
-
   private operaSubproductsFromScene(product: models.CMRProduct) {
     product.metadata.s3URI = product.metadata.opera.s3Urls[0]
     if (product.metadata.opera?.validityStartDate) {
@@ -211,11 +195,11 @@ export class ProductService {
     if (['DISP-S1', 'TROPO-ZENITH'].includes(product.metadata.productType)) {
       file_suffix = 'nc';
     } else {
-      file_suffix = this.urlToProductType(product.downloadUrl, this.operaProductTypeDisplays);
+      file_suffix = this.urlToProductType(product.downloadUrl, models.opera_s1.productTypeDisplays);
     }
 
     product.productTypeDisplay =
-      this.operaProductTypeDisplays[file_suffix?.toLowerCase()] ?? 'Download';
+      models.opera_s1.productTypeDisplays[file_suffix?.toLowerCase()] ?? 'Download';
 
     const thumbnail_index = product.browses.findIndex((url) =>
       url.toLowerCase().includes('thumbnail'),
@@ -236,10 +220,10 @@ export class ProductService {
     for (const p of product.metadata.opera.additionalUrls.filter(
       (url) => url !== product.downloadUrl,
     )) {
-      file_suffix = this.urlToProductType(p, this.operaProductTypeDisplays);
+      file_suffix = this.urlToProductType(p, models.opera_s1.productTypeDisplays);
 
       let productTypeDisplay =
-        this.operaProductTypeDisplays[file_suffix?.toLowerCase()];
+        models.opera_s1.productTypeDisplays[file_suffix?.toLowerCase()];
       if (
         product.metadata.productType === 'DISP-S1' &&
         productTypeDisplay == null
@@ -279,33 +263,10 @@ export class ProductService {
     });
   }
 
-  private nisarProductTypeDisplays = {
-    yaml: 'Runconfig YAML',
-    kml: 'Footprint KML',
-    png: 'Browse Image PNG',
-    csv: 'QA Summary CSV',
-    h5: 'HDF5',
-    xml: 'ISO Metadata XML',
-    json: 'Metadata JSON',
-    pdf: 'QA Report PDF',
-    log: 'Log File',
-    qa: 'QA Statistics HDF5',
-    bin: 'Bin File',
-  };
-
-public seasatProductTypeDisplays = {
-    h5: 'Level One HDF5 Image',
-    in: 'Metadata IN',
-    tif: 'Level One GeoTIFF Product',
-    xml: 'ISO Metadata XML',
-    kml: 'Metadata KML',
-    qc_report: 'QC Report',
-    jpg: 'Browse Image JPEG'
-  };
 private seasatSubproductsFromScene(product: models.CMRProduct) {
     const products = [];
-    let file_extension = this.urlToProductType(product.downloadUrl, this.seasatProductTypeDisplays)
-    product.productTypeDisplay = this.seasatProductTypeDisplays[file_extension];
+    let file_extension = this.urlToProductType(product.downloadUrl, models.seasat.productTypeDisplays)
+    product.productTypeDisplay = models.seasat.productTypeDisplays[file_extension];
     let fileID = product.downloadUrl.split('/').slice(-1)[0];
     product.bytes = product.metadata.fileSizes[fileID].bytes
     const thumbnail_index = product.browses.findIndex((url) =>
@@ -336,10 +297,10 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
       ),
       ...product.browses,
     ]) {
-      file_extension = this.urlToProductType(p, this.seasatProductTypeDisplays)
+      file_extension = this.urlToProductType(p, models.seasat.productTypeDisplays)
 
       let productTypeDisplay =
-        this.seasatProductTypeDisplays[file_extension.toLowerCase()] ??
+        models.seasat.productTypeDisplays[file_extension.toLowerCase()] ??
         'Missing Display';
       if (productTypeDisplay === 'Missing Display') {
         console.log(
@@ -444,7 +405,7 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
       temp = p.split('.');
       file_extension = temp[temp.length - 1];
       let productTypeDisplay =
-        this.nisarProductTypeDisplays[file_extension.toLowerCase()] ??
+        models.nisar.productTypeDisplays[file_extension.toLowerCase()] ??
         'Missing Display';
       if (productTypeDisplay === 'Missing Display') {
         if (file_extension.includes('vc')) {
@@ -461,7 +422,7 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
         }
       }
       if (p.endsWith('.h5') && p.includes('QA_')) {
-        productTypeDisplay = this.nisarProductTypeDisplays.qa;
+        productTypeDisplay = models.nisar.productTypeDisplays.qa;
       }
 
       if (['Log File', 'Metadata JSON'].includes(productTypeDisplay)) {

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -455,8 +455,10 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
           );
         }
       }
-      if (productTypeDisplay === 'Browse PNG') {
-        browses.push(p);
+      if (productTypeDisplay === 'Browse Image PNG') {
+        if (p === '/assets/no-browse.png') {
+          continue
+        }
       }
       if (p.endsWith('.h5') && p.includes('QA_')) {
         productTypeDisplay = this.nisarProductTypeDisplays.qa;

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -198,6 +198,7 @@ export class ProductService {
   };
 
   private operaSubproductsFromScene(product: models.CMRProduct) {
+    product.metadata.s3URI = product.metadata.opera.s3Urls[0]
     if (product.metadata.opera?.validityStartDate) {
       product.metadata.opera.validityStartDate = this.fromCMRDate(
         product.metadata.opera?.validityStartDate as unknown as string,
@@ -222,6 +223,14 @@ export class ProductService {
     if (thumbnail_index !== -1) {
       product.thumbnail = product.browses.splice(thumbnail_index, 1)[0];
     }
+
+    const s3Index = product.metadata.opera.s3Urls.findIndex((uri) =>
+        uri.toLowerCase().endsWith(file_suffix)
+    )
+
+    if(s3Index !== -1) {
+        product.metadata.s3URI = product.metadata.opera.s3Urls[s3Index];
+    }
     product.browses = product.browses.filter((url) => !url.includes('low-res'));
 
     for (const p of product.metadata.opera.additionalUrls.filter(
@@ -243,23 +252,12 @@ export class ProductService {
       }
       const fileID = p.split('/').slice(-1)[0];
 
-      const subproduct = {
-        ...product,
-        downloadUrl: p,
-        productTypeDisplay: productTypeDisplay || p,
-        file: fileID,
-        id: product.id + '-' + file_suffix,
-        bytes: 0,
-        browses: [],
-        thumbnail: null,
-        metadata: {
-          ...product.metadata,
-          productType: product.metadata.productType,
-          parentID: product.id,
-          subproducts: [],
-        },
-      } as models.CMRProduct;
-
+      let s3Uri = null;
+      let s3uriIndex = product.metadata.opera.s3Urls.findIndex(x => x.split('/').slice(-1)[0] === fileID)
+      if (s3uriIndex !== -1) {
+        s3Uri = product.metadata.opera.s3Urls[s3uriIndex]
+      }
+      const subproduct =this.createSubproductForScene(product, p, s3Uri, file_suffix, productTypeDisplay, 0, [])
       products.push(subproduct);
     }
 
@@ -355,25 +353,9 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
 
       const fileID = p.split('/').slice(-1)[0];
       const s3Url = s3UrlsByProductID[fileID] ?? null;
+      const fileSize = product.metadata.fileSizes[fileID]?.bytes ?? 0
+      const subproduct = this.createSubproductForScene(product, p, s3Url, file_extension, productTypeDisplay, fileSize, browses)
 
-      const subproduct = {
-        ...product,
-        downloadUrl: p,
-        productTypeDisplay: productTypeDisplay || p,
-        file: fileID,
-        id: product.id + '-' + file_extension,
-        bytes: product.metadata.fileSizes[fileID]?.bytes ?? 0,
-        browses,
-        thumbnail: null,
-        metadata: {
-          ...product.metadata,
-          productType: product.metadata.productType,
-          parentID: product.id,
-          subproducts: [],
-          s3URI: s3Url,
-        },
-        virtual: true,
-      } as models.CMRProduct;
       products.push(subproduct);
     }
 
@@ -393,6 +375,28 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
       return a.productTypeDisplay < b.productTypeDisplay ? -1 : 1;
     });
   }
+
+  private createSubproductForScene(scene: models.CMRProduct, url: string, s3uri: string, fileExtension: string, productTypeDisplay: string | null, fileSize: number, browses: string[]) {
+    const fileID = url.split('/').slice(-1)[0];
+    return {
+        ...scene,
+        downloadUrl: url,
+        productTypeDisplay: productTypeDisplay || url,
+        file: fileID,
+        id: scene.id + '-' + fileExtension,
+        bytes: fileSize,
+        browses,
+        thumbnail: null,
+        metadata: {
+          ...scene.metadata,
+          productType: scene.metadata.productType,
+          parentID: scene.id,
+          subproducts: [],
+          s3URI: s3uri,
+        },
+        virtual: true,
+      } as models.CMRProduct;
+    } 
 
   private nisarSubproductsFromScene(product: models.CMRProduct) {
     const products = [];
@@ -464,25 +468,9 @@ private seasatSubproductsFromScene(product: models.CMRProduct) {
 
       const fileID = p.split('/').slice(-1)[0];
       const s3Url = s3UrlsByProductID[fileID] ?? null;
+      const fileSize = product.metadata.nisar?.sizeMB?.[fileID]?.bytes ?? 0
+      const subproduct = this.createSubproductForScene(product, p, s3Url, file_extension, productTypeDisplay, fileSize, browses)
 
-      const subproduct = {
-        ...product,
-        downloadUrl: p,
-        productTypeDisplay: productTypeDisplay || p,
-        file: fileID,
-        id: product.id + '-' + file_extension,
-        bytes: product.metadata.nisar?.sizeMB?.[fileID]?.bytes ?? 0,
-        browses,
-        thumbnail: null,
-        metadata: {
-          ...product.metadata,
-          productType: product.metadata.productType,
-          parentID: product.id,
-          subproducts: [],
-          s3URI: s3Url,
-        },
-        virtual: true,
-      } as models.CMRProduct;
       products.push(subproduct);
     }
 


### PR DESCRIPTION
### Changed
- SEASAT Dataset: Removed SEASAT product type selections
- SEASAT Dataset: uses beammode instead of beamswath for beammode searches now
- OPERA Dataset: Fix s3 clipboard copying from files list
- NISAR Dataset: Fix no-browse.png appearing in files list on results without browses

### Added
- SEASAT Dataset: Added ISO XML, KML, QC Report, and Browse image to result files list
   - All files can be added to download queue by file type

SEASAT Dataset Migration Notes: SEASAT's two collections for GEOTIFF and HDF5 products have been consolidated into a single collection and its CMR metadata record has been modernized. Searching for the equivalent product across both product types is no longer necessary.