### PR TITLE
Address UI Issues - Tyler

### DIFF
--- a/src/app/components/results-menu/scene-detail/scene-detail.component.scss
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.scss
@@ -160,6 +160,7 @@ a {
   position: sticky;
   display: flex;
   justify-content: flex-start;
+  flex-wrap: nowrap; // Prevent wrapping
 
   @include themify($themes) {
     background: lighten(themed("primary-light"), 8%);
@@ -173,6 +174,10 @@ a {
   align-items: center;
   height: 40px;
   bottom: 0;
+
+  button {
+    flex: 0 0 auto !important; // Prevent buttons from growing
+  }
 
   button:enabled {
     cursor: pointer;
@@ -203,6 +208,10 @@ a {
 
 .search-button {
   margin-left: 20px;
+  width: auto !important; // Prevent expansion
+  flex: 0 0 auto !important; // Don't grow or shrink
+  min-width: 80px; // Set minimum width
+  max-width: fit-content; // Don't exceed content width
 
   @include themify($themes) {
     background-color: themed("primary");

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.scss
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.scss
@@ -209,7 +209,6 @@ a {
 .search-button {
   margin-left: 20px;
   width: auto !important; // Prevent expansion
-  flex: 0 0 auto !important; // Don't grow or shrink
   min-width: 80px; // Set minimum width
   max-width: fit-content; // Don't exceed content width
 

--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.component.html
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.component.html
@@ -93,11 +93,12 @@
     [matMenuTriggerFor]="customJobTypes"
     mat-icon-button
     matListItemMeta
-    class="hype-icon-button mat-icon-button"
+    class="hype-icon-button"
   >
     <mat-icon
       *ngIf="loadingHyp3JobName !== product.name"
       svgIcon="hyp3"
+      class="hype-icon-button"
       matTooltip="{{ 'ADD_TO_ON_DEMAND_QUEUE' | translate }}"
     >
     </mat-icon>

--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.component.scss
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.component.scss
@@ -27,4 +27,12 @@
   align-items: center;
   justify-content: center;
   margin-top: 1px;
+
+  mat-icon {
+    opacity: 1 !important; // Ensure icon is not faded
+  }
+
+  &:not([disabled]) mat-icon {
+    opacity: 1 !important;
+  }
 }

--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.component.scss
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.component.scss
@@ -1,3 +1,5 @@
+@use "asf-theme-variables" as *;
+
 .icon-margin {
   margin-left: 5px;
   span {
@@ -28,11 +30,7 @@
   justify-content: center;
   margin-top: 1px;
 
-  mat-icon {
-    opacity: 1 !important; // Ensure icon is not faded
-  }
-
-  &:not([disabled]) mat-icon {
-    opacity: 1 !important;
+  @include themify($themes) {
+    color: themed('light-black');
   }
 }

--- a/src/app/components/shared/hyp3-url/hyp3-url.component.scss
+++ b/src/app/components/shared/hyp3-url/hyp3-url.component.scss
@@ -3,4 +3,5 @@
   height: 19px;
   margin-right: 5px;
   vertical-align: sub;
+  opacity: 1 !important; // Ensure icon is not faded
 }

--- a/src/app/components/shared/scene-metadata/scene-metadata.component.html
+++ b/src/app/components/shared/scene-metadata/scene-metadata.component.html
@@ -232,7 +232,7 @@
   <li *ngIf="prop.isRelevant(p.COVERAGE_ANGLE, dataset)">
     <span class="v-mid">
       <b>{{ 'FRAME_COVERAGE' | translate }} </b> •
-      {{ scene.metadata.nisar.frameCoverage }}
+      {{ scene.metadata.nisar?.frameCoverage }}
     </span>
   </li>
 
@@ -288,7 +288,7 @@
   >
     <span class="v-mid">
       <b>{{ 'POLARIZATION_MAIN' | translate }} </b> •
-      {{ scene.metadata.nisar.mainBandPolarization }}
+      {{ scene.metadata.nisar?.mainBandPolarization }}
     </span>
 
     <mat-icon
@@ -308,7 +308,7 @@
   <li *ngIf="prop.isRelevant(p.SIDE_POLARIZATION, dataset)">
     <span class="v-mid">
       <b>{{ 'POLARIZATION_SIDE' | translate }} </b> •
-      {{ scene.metadata.nisar.sideBandPolarization }}
+      {{ scene.metadata.nisar?.sideBandPolarization }}
     </span>
 
     <mat-icon
@@ -329,7 +329,7 @@
   <li *ngIf="prop.isRelevant(p.RANGE_BANDWIDTH, dataset)">
     <span class="v-mid">
       <b>{{ 'RANGE_BANDWIDTH' | translate }} </b> •
-      {{ scene.metadata.nisar.rangeBandwidth }}
+      {{ scene.metadata.nisar?.rangeBandwidth }}
     </span>
 
     <mat-icon
@@ -350,7 +350,7 @@
   <li *ngIf="prop.isRelevant(p.RANGE_BANDWIDTH, dataset)">
     <span class="v-mid">
       <b>{{ 'JOINT_OBSERVATION_ONLY' | translate }} </b> •
-      {{ scene.metadata.nisar.jointObservation }}
+      {{ scene.metadata.nisar?.jointObservation }}
     </span>
   </li>
 

--- a/src/app/components/shared/scene-metadata/scene-metadata.component.ts
+++ b/src/app/components/shared/scene-metadata/scene-metadata.component.ts
@@ -104,7 +104,7 @@ export class SceneMetadataComponent implements OnInit, OnDestroy {
   }
   public setFrameCoverage(): void {
     const action = new filtersStore.setFrameCoverage([
-      this.scene.metadata.nisar.frameCoverage,
+      this.scene.metadata.nisar?.frameCoverage,
     ]);
     this.store$.dispatch(action);
   }
@@ -117,13 +117,13 @@ export class SceneMetadataComponent implements OnInit, OnDestroy {
   }
   public addMainPolarization(): void {
     const action = new filtersStore.AddPolarization(
-      this.scene.metadata.nisar.mainBandPolarization,
+      this.scene.metadata.nisar?.mainBandPolarization,
     );
     this.store$.dispatch(action);
   }
   public addSidePolarization(): void {
     const action = new filtersStore.AddSidePolarization(
-      this.scene.metadata.nisar.sideBandPolarization,
+      this.scene.metadata.nisar?.sideBandPolarization,
     );
     this.store$.dispatch(action);
   }
@@ -137,7 +137,7 @@ export class SceneMetadataComponent implements OnInit, OnDestroy {
 
   public addRangeBandwidth(): void {
     const action = new filtersStore.addRangeBandwidth(
-      this.scene.metadata.nisar.rangeBandwidth,
+      this.scene.metadata.nisar?.rangeBandwidth,
     );
     this.store$.dispatch(action);
   }

--- a/src/app/components/shared/search-button/search-button.component.scss
+++ b/src/app/components/shared/search-button/search-button.component.scss
@@ -6,6 +6,15 @@
   @include themify($themes) {
     background-color: themed('primary') !important;
   }
+
+  // Fix arrow color on hover
+  mat-icon {
+    color: #ddd !important;
+  }
+
+  &:hover mat-icon {
+    color: #ddd !important;
+  }
 }
 .search-button {
   height: 36px !important;

--- a/src/app/components/shared/selectors/season-selector/season-selector.component.ts
+++ b/src/app/components/shared/selectors/season-selector/season-selector.component.ts
@@ -60,11 +60,8 @@ export class SeasonSelectorComponent implements OnInit, OnDestroy {
     if (!event.checked) {
       this.store$.dispatch(new filtersStore.ClearSeason());
     } else {
-      // Batch dispatch to reduce lag from multiple state updates
-      setTimeout(() => {
-        this.store$.dispatch(new filtersStore.SetSeasonStart(1));
-        this.store$.dispatch(new filtersStore.SetSeasonEnd(180));
-      }, 0);
+      // Dispatch a single action to update both start and end to batch state updates
+      this.store$.dispatch(new filtersStore.SetSeasonRange({ start: 1, end: 180 }));
     }
   }
 

--- a/src/app/components/shared/selectors/season-selector/season-selector.component.ts
+++ b/src/app/components/shared/selectors/season-selector/season-selector.component.ts
@@ -60,9 +60,11 @@ export class SeasonSelectorComponent implements OnInit, OnDestroy {
     if (!event.checked) {
       this.store$.dispatch(new filtersStore.ClearSeason());
     } else {
-      // Dispatch a single action to update both start and end to batch state updates
-      this.store$.dispatch(new filtersStore.SetSeasonRange({ start: 1, end: 180 }));
-    }
+      // Batch dispatch to reduce lag from multiple state updates
+      setTimeout(() => {
+        this.store$.dispatch(new filtersStore.SetSeasonStart(1));
+        this.store$.dispatch(new filtersStore.SetSeasonEnd(180));
+      }, 0);    }
   }
 
   public onSeasonStartChange(dayOfYear: number): void {

--- a/src/app/components/shared/selectors/season-selector/season-selector.component.ts
+++ b/src/app/components/shared/selectors/season-selector/season-selector.component.ts
@@ -60,8 +60,11 @@ export class SeasonSelectorComponent implements OnInit, OnDestroy {
     if (!event.checked) {
       this.store$.dispatch(new filtersStore.ClearSeason());
     } else {
-      this.store$.dispatch(new filtersStore.SetSeasonStart(1));
-      this.store$.dispatch(new filtersStore.SetSeasonEnd(180));
+      // Batch dispatch to reduce lag from multiple state updates
+      setTimeout(() => {
+        this.store$.dispatch(new filtersStore.SetSeasonStart(1));
+        this.store$.dispatch(new filtersStore.SetSeasonEnd(180));
+      }, 0);
     }
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -53,7 +53,7 @@ $theme-map: null;
   top: 140px;
   right: 10px;
   float: right;
-  z-index: 1099;
+  z-index: 9999; // Higher than dialog overlay (2000) to appear above download queue
 }
 
 // toast style overrides

--- a/src/styles/asf-theme-variables.scss
+++ b/src/styles/asf-theme-variables.scss
@@ -37,6 +37,8 @@ $asf-background-white: lighten($asf-primary, 80%);
 
 $themes: (
   light: (
+    light-white: white,
+    light-black: rgb(0 0 0 / 0.87),
     background-white: lighten(mat.m2-get-color-from-palette($asf-app-primary), 80%),
     dark-primary-text: rgb(0 0 0 / 0.87),
     dark-secondary-text: rgb(0 0 0 / 0.54),
@@ -59,6 +61,8 @@ $themes: (
     primary-dark: darken(mat.m2-get-color-from-palette($asf-app-primary), 15%),
   ),
   dark: (
+    light-white: black,
+    light-black: white,
     light-primary-text: white,
     light-secondary-text: rgb(255 255 255 / 0.54),
     light-disabled-text: rgb(255 255 255 / 0.38),


### PR DESCRIPTION
## Summary
This should address UI issues raised by Tyler

- Search button arrow turns black on hover
- When in the download queue, and copying file IDs and urls the notification toast no longer shows above the download queue.
- Hyp3 on demand icons are faded in some places, specifically for product files list and baseline searches.
- Baseline search option buttons at the bottom of the details of the scene, the buttons are expanding more than they should and taking up the full width
- the seasonal search toggle seems like it lags when switching over?
