### PR TITLE
DS-6299 Only Equatorial view is valid for Displacement Searches

### DIFF
--- a/src/app/components/map/map-controls/view-selector/view-selector.component.html
+++ b/src/app/components/map/map-controls/view-selector/view-selector.component.html
@@ -30,6 +30,7 @@
     aria-label="Arctic map projection"
     (click)="onArcticSelected()"
     [value]="types.ARCTIC"
+    [disabled]="isDisplacementSearch"
   >
     <mat-icon
       svgIcon="arctic"
@@ -59,6 +60,7 @@
     aria-label="Antarctic map projection"
     (click)="onAntarcticSelected()"
     [value]="types.ANTARCTIC"
+    [disabled]="isDisplacementSearch"
   >
     <mat-icon
       svgIcon="antarctic"

--- a/src/app/components/map/map-controls/view-selector/view-selector.component.ts
+++ b/src/app/components/map/map-controls/view-selector/view-selector.component.ts
@@ -4,8 +4,9 @@ import { SubSink } from 'subsink';
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
 import * as mapStore from '@store/map';
+import * as searchStore from '@store/search';
 
-import { MapViewType } from '@models';
+import { MapViewType, SearchType } from '@models';
 
 // Declare GTM dataLayer array.
 declare global {
@@ -25,6 +26,7 @@ export class ViewSelectorComponent implements OnInit, OnDestroy {
 
   public view: MapViewType;
   public types = MapViewType;
+  public isDisplacementSearch = false;
   private subs = new SubSink();
 
   ngOnInit() {
@@ -36,6 +38,12 @@ export class ViewSelectorComponent implements OnInit, OnDestroy {
           event: 'map-view',
           'map-view': this.view,
         });
+      }),
+    );
+
+    this.subs.add(
+      this.store$.select(searchStore.getSearchType).subscribe((searchType) => {
+        this.isDisplacementSearch = searchType === SearchType.DISPLACEMENT;
       }),
     );
   }

--- a/src/app/components/shared/scene-metadata/scene-metadata.component.html
+++ b/src/app/components/shared/scene-metadata/scene-metadata.component.html
@@ -232,7 +232,7 @@
   <li *ngIf="prop.isRelevant(p.COVERAGE_ANGLE, dataset)">
     <span class="v-mid">
       <b>{{ 'FRAME_COVERAGE' | translate }} </b> •
-      {{ scene.metadata.nisar.frameCoverage }}
+      {{ scene.metadata.nisar?.frameCoverage }}
     </span>
   </li>
 
@@ -288,7 +288,7 @@
   >
     <span class="v-mid">
       <b>{{ 'POLARIZATION_MAIN' | translate }} </b> •
-      {{ scene.metadata.nisar.mainBandPolarization }}
+      {{ scene.metadata.nisar?.mainBandPolarization }}
     </span>
 
     <mat-icon
@@ -308,7 +308,7 @@
   <li *ngIf="prop.isRelevant(p.SIDE_POLARIZATION, dataset)">
     <span class="v-mid">
       <b>{{ 'POLARIZATION_SIDE' | translate }} </b> •
-      {{ scene.metadata.nisar.sideBandPolarization }}
+      {{ scene.metadata.nisar?.sideBandPolarization }}
     </span>
 
     <mat-icon
@@ -329,7 +329,7 @@
   <li *ngIf="prop.isRelevant(p.RANGE_BANDWIDTH, dataset)">
     <span class="v-mid">
       <b>{{ 'RANGE_BANDWIDTH' | translate }} </b> •
-      {{ scene.metadata.nisar.rangeBandwidth }}
+      {{ scene.metadata.nisar?.rangeBandwidth }}
     </span>
 
     <mat-icon
@@ -350,7 +350,7 @@
   <li *ngIf="prop.isRelevant(p.RANGE_BANDWIDTH, dataset)">
     <span class="v-mid">
       <b>{{ 'JOINT_OBSERVATION_ONLY' | translate }} </b> •
-      {{ scene.metadata.nisar.jointObservation }}
+      {{ scene.metadata.nisar?.jointObservation }}
     </span>
   </li>
 

--- a/src/app/components/shared/scene-metadata/scene-metadata.component.ts
+++ b/src/app/components/shared/scene-metadata/scene-metadata.component.ts
@@ -104,7 +104,7 @@ export class SceneMetadataComponent implements OnInit, OnDestroy {
   }
   public setFrameCoverage(): void {
     const action = new filtersStore.setFrameCoverage([
-      this.scene.metadata.nisar.frameCoverage,
+      this.scene.metadata.nisar?.frameCoverage,
     ]);
     this.store$.dispatch(action);
   }
@@ -117,13 +117,13 @@ export class SceneMetadataComponent implements OnInit, OnDestroy {
   }
   public addMainPolarization(): void {
     const action = new filtersStore.AddPolarization(
-      this.scene.metadata.nisar.mainBandPolarization,
+      this.scene.metadata.nisar?.mainBandPolarization,
     );
     this.store$.dispatch(action);
   }
   public addSidePolarization(): void {
     const action = new filtersStore.AddSidePolarization(
-      this.scene.metadata.nisar.sideBandPolarization,
+      this.scene.metadata.nisar?.sideBandPolarization,
     );
     this.store$.dispatch(action);
   }
@@ -137,7 +137,7 @@ export class SceneMetadataComponent implements OnInit, OnDestroy {
 
   public addRangeBandwidth(): void {
     const action = new filtersStore.addRangeBandwidth(
-      this.scene.metadata.nisar.rangeBandwidth,
+      this.scene.metadata.nisar?.rangeBandwidth,
     );
     this.store$.dispatch(action);
   }


### PR DESCRIPTION
Summary
Modified the view selector to make Equatorial View the only enabled option for Displacement Searches.

During Displacement Search:
✅ Equatorial View - Enabled and clickable
❌ Arctic View - Disabled (grayed out, not clickable)
❌ Antarctic View - Disabled (grayed out, not clickable)

During Other Search Modes (Dataset, Baseline, SBAS, etc.):
✅ All three view options remain enabled, and users can freely switch between them