### PR TITLE
Update job project name

### DIFF
--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.component.html
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.component.html
@@ -137,7 +137,27 @@
   @if (product.metadata.job) {
     <ng-container>
       <div *ngIf="product.metadata.job.name" matListItemLine>
-        <b>{{ 'PROJECT_NAME' | translate }}:</b> {{ product.metadata.job.name }}
+      <b>{{ 'PROJECT_NAME' | translate }}:</b> {{ product.metadata.job.name }}
+
+      @if (!isEditingProjectName) {
+      <button mat-icon-button (click)="onEditProjectName(product.metadata.job.name)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      }
+
+      @if (isEditingProjectName) {
+        <div>
+          <input
+            type="text"
+            id="projectNameInput"
+            [(ngModel)]="newProjectName"
+            placeholder="Enter name"
+          />
+          <button (click)="onSubmitProjectName()">Save</button>
+        </div>
+      }
+
+
       </div>
 
       <div matListItemLine>

--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.component.ts
@@ -53,12 +53,16 @@ export class SceneFileComponent implements OnInit, OnDestroy {
   @Output() unzip = new EventEmitter<models.CMRProduct>();
   @Output() closeProduct = new EventEmitter<models.CMRProduct>();
   @Output() queueHyp3Job = new EventEmitter<models.QueuedHyp3Job>();
+  @Output() renameJobProjectName = new EventEmitter<string>();
 
   public searchType$ = this.store$.select(searchStore.getSearchType);
   public searchTypes = SearchType;
   public isHovered = false;
   public paramsList = [];
   public copyIcons = models.CopyIcons;
+
+  public newProjectName = '';
+  public isEditingProjectName = false;
 
   private subs = new SubSink();
 
@@ -153,6 +157,17 @@ export class SceneFileComponent implements OnInit, OnDestroy {
         job_type: job_types[job_type],
       }),
     );
+  }
+
+  public onEditProjectName(oldProjectName: string) {
+    this.newProjectName = oldProjectName;
+    this.isEditingProjectName = true;
+  }
+
+  public onSubmitProjectName() {
+    this.renameJobProjectName.emit(this.newProjectName);
+    this.isEditingProjectName = false;
+    this.newProjectName = '';
   }
 
   private expirationDays(expiration_time: moment.Moment): number {

--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.module.ts
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.module.ts
@@ -1,5 +1,6 @@
 import { NgModule, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatMenuModule } from '@angular/material/menu';
 
@@ -23,6 +24,7 @@ import { SharedModule } from '@shared';
   declarations: [SceneFileComponent],
   imports: [
     CommonModule,
+    FormsModule,
     FontAwesomeModule,
     MatSharedModule,
     MatMenuModule,

--- a/src/app/components/results-menu/scene-files/scene-files.component.html
+++ b/src/app/components/results-menu/scene-files/scene-files.component.html
@@ -16,6 +16,7 @@
       (toggle)="onToggleQueueProduct(product)"
       (unzip)="onOpenUnzipProduct($event)"
       (queueHyp3Job)="onQueueHyp3Job($event)"
+      (renameJobProjectName)="onRenameJobProjectName(product, $event)"
       [loadingHyp3JobName]="loadingHyp3JobName"
       [isUserLoggedIn]="isUserLoggedIn"
       [product]="product"

--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -328,6 +328,14 @@ export class SceneFilesComponent
     this.store$.dispatch(new queueStore.AddJob(job));
   }
 
+  public onRenameJobProjectName(product: models.CMRProduct, newProjectName: string) {
+    const job = product.metadata.job;
+    this.hyp3.updateJobName$(job.job_id, newProjectName).subscribe((job) => {
+      const action = new scenesStore.UpdateProductWithNewProjectName({ productId: product.id, name: job.name });
+      this.store$.dispatch(action);
+    });
+  }
+
   public formatProductName(product_name: string, desiredLen?: number) {
     const extrasWidthPx = 260;
     const charWidthPx = 10;

--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
@@ -322,7 +322,52 @@
                 </button>
               </div>
             </mat-menu>
+          @if (!isEditingProjectName) {
+            <div class="fx-empty list-button-group">
+              <div class="fx-row-center button-group-label">
+                <label>Project</label>
+              </div>
+              <div class="fx-row">
+                <div class="scenes-list-button-container">
+                  <mat-button-toggle-group
+                    name="layerType"
+                    class="fx-empty mr-10"
+                    [hideSingleSelectionIndicator]="true"
+                  >
+                    <mat-button-toggle
+                      class="control-mat-button-toggle clickable noselect"
+                      [matMenuTriggerFor]="BulkProjectNameUpdate"
+                      matTooltip="Update project name for all loaded jobs"
+                    >
+                      <mat-icon class="list-icon"> edit </mat-icon>
+                    </mat-button-toggle>
+                  </mat-button-toggle-group>
+                </div>
+              </div>
+            </div>
+
+            <mat-menu #BulkProjectNameUpdate="matMenu">
+              <div>
+                <button (click)="onBulkProjectNameUpdate()" mat-menu-item>
+                Update project name for {{ products.length }} jobs
+                </button>
+              </div>
+            </mat-menu>
+            }
           }
+
+          @if (isEditingProjectName) {
+            <div class="fx-row-center">
+              <input
+                type="text"
+                id="projectNameInput"
+                [(ngModel)]="newProjectName"
+                placeholder="Enter name"
+              />
+              <button (click)="onSubmitProjectName()">Save</button>
+            </div>
+          }
+
 
           <div
             *ngIf="searchType === SearchTypes.BASELINE"

--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.ts
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { saveAs } from 'file-saver';
 
-import { combineLatest, switchMap, from } from 'rxjs';
+import { combineLatest, switchMap } from 'rxjs';
 import {
   debounceTime,
   filter,
@@ -9,8 +9,6 @@ import {
   take,
   tap,
   withLatestFrom,
-  mergeMap,
-  toArray,
 } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
@@ -652,22 +650,11 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
 
   public onSubmitProjectName() {
     this.isEditingProjectName = false;
-    const newName = this.newProjectName;
 
-    from(this.products).pipe(
-      mergeMap(
-        (product) => {
-          console.log(product.metadata.job.job_id);
-          return this.hyp3.updateJobName$(product.metadata.job.job_id, newName);
-        },
-        20
-      ),
-      toArray(),
-    ).subscribe(resps => {
-      console.log(resps);
-    });
+    this.hyp3
+      .updateJobsName$(this.products, this.newProjectName)
+      .subscribe(console.log);
 
-    console.log(`updating with ${this.newProjectName}`);
     this.newProjectName = '';
   }
 

--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.ts
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { saveAs } from 'file-saver';
 
-import { combineLatest, switchMap } from 'rxjs';
+import { combineLatest, switchMap, from } from 'rxjs';
 import {
   debounceTime,
   filter,
@@ -9,6 +9,8 @@ import {
   take,
   tap,
   withLatestFrom,
+  mergeMap,
+  toArray,
 } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
@@ -271,6 +273,9 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
   public moreHyp3JobsToLoad: boolean;
 
   private selectedEvent: models.SarviewsEvent;
+
+  public isEditingProjectName = false;
+  public newProjectName = '';
 
   ngOnInit() {
     this.subs.add(
@@ -638,6 +643,32 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
           maxHeight: '500px',
         });
       });
+  }
+
+  public onBulkProjectNameUpdate() {
+    this.isEditingProjectName = true;
+    this.newProjectName = '';
+  }
+
+  public onSubmitProjectName() {
+    this.isEditingProjectName = false;
+    const newName = this.newProjectName;
+
+    from(this.products).pipe(
+      mergeMap(
+        (product) => {
+          console.log(product.metadata.job.job_id);
+          return this.hyp3.updateJobName$(product.metadata.job.job_id, newName);
+        },
+        20
+      ),
+      toArray(),
+    ).subscribe(resps => {
+      console.log(resps);
+    });
+
+    console.log(`updating with ${this.newProjectName}`);
+    this.newProjectName = '';
   }
 
   ngOnDestroy(): void {

--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.module.ts
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
@@ -15,6 +16,7 @@ import { MatIconModule } from '@angular/material/icon';
   declarations: [ScenesListHeaderComponent],
   imports: [
     CommonModule,
+    FormsModule,
     MatMenuModule,
     MatIconModule,
     MatSharedModule,

--- a/src/app/services/hyp3/hyp3-api.service.ts
+++ b/src/app/services/hyp3/hyp3-api.service.ts
@@ -161,8 +161,7 @@ export class Hyp3ApiService {
     const url = `${this.apiUrl}/jobs/${jobId}`;
 
     return this.http.patch<models.Hyp3Job>(url, { name: projectName }, { withCredentials: true })
-      .pipe(map((resp) => resp as models.Hyp3Job)
-      );
+      .pipe(map((resp) => resp as models.Hyp3Job));
   }
 
   public submitJobBatch$(jobBatch: object) {

--- a/src/app/services/hyp3/hyp3-api.service.ts
+++ b/src/app/services/hyp3/hyp3-api.service.ts
@@ -157,6 +157,14 @@ export class Hyp3ApiService {
     );
   }
 
+  public updateJobName$(jobId: string, projectName: string): Observable<models.Hyp3Job> {
+    const url = `${this.apiUrl}/jobs/${jobId}`;
+
+    return this.http.patch<models.Hyp3Job>(url, { name: projectName }, { withCredentials: true })
+      .pipe(map((resp) => resp as models.Hyp3Job)
+      );
+  }
+
   public submitJobBatch$(jobBatch: object) {
     const submitJobUrl = `${this.apiUrl}/jobs`;
 

--- a/src/app/services/hyp3/hyp3-api.service.ts
+++ b/src/app/services/hyp3/hyp3-api.service.ts
@@ -5,7 +5,8 @@ import {
   HttpParams,
 } from '@angular/common/http';
 
-import { Observable, of, first, catchError, map, forkJoin } from 'rxjs';
+import { Observable, of, first, catchError, map, forkJoin, from } from 'rxjs';
+import { mergeMap, toArray, bufferCount } from 'rxjs/operators';
 import * as moment from 'moment';
 
 import * as models from '@models';
@@ -157,11 +158,47 @@ export class Hyp3ApiService {
     );
   }
 
-  public updateJobName$(jobId: string, projectName: string): Observable<models.Hyp3Job> {
+  public updateJobName$(
+    jobId: string,
+    newProjectName: string,
+  ): Observable<models.Hyp3Job> {
     const url = `${this.apiUrl}/jobs/${jobId}`;
 
-    return this.http.patch<models.Hyp3Job>(url, { name: projectName }, { withCredentials: true })
+    if (!newProjectName) {
+      newProjectName = null;
+    }
+
+    return this.http
+      .patch<models.Hyp3Job>(
+        url,
+        { name: newProjectName },
+        { withCredentials: true },
+      )
       .pipe(map((resp) => resp as models.Hyp3Job));
+  }
+
+  public updateJobsName$(
+    products: models.CMRProduct[],
+    newProjectName: string,
+  ): Observable<any> {
+    const url = `${this.apiUrl}/jobs`;
+    const jobIds = products.map((product) => product.metadata.job.job_id);
+
+    if (!newProjectName) {
+      newProjectName = null;
+    }
+
+    return from(jobIds).pipe(
+      bufferCount(100),
+      mergeMap((jobIdsBatch) => {
+        return this.http.patch<models.Hyp3Job>(
+          url,
+          { name: newProjectName, job_ids: jobIdsBatch },
+          { withCredentials: true },
+        );
+      }, 5),
+      toArray(),
+    );
   }
 
   public submitJobBatch$(jobBatch: object) {

--- a/src/app/services/hyp3/hyp3-job.service.ts
+++ b/src/app/services/hyp3/hyp3-job.service.ts
@@ -195,7 +195,7 @@ export class Hyp3JobService {
     return newJobProducts;
   }
 
-  private combineJobAndCmrProduct(
+  public combineJobAndCmrProduct(
     job: models.Hyp3Job,
     product: models.CMRProduct,
   ) {

--- a/src/app/store/scenes/scenes.action.ts
+++ b/src/app/store/scenes/scenes.action.ts
@@ -9,6 +9,7 @@ import {
   SarviewsEvent,
   SarviewsProduct,
   CMRProductsById,
+  // Hyp3Job,
 } from '@models';
 import { PinnedProduct } from '@services/browse-map.service';
 
@@ -29,6 +30,7 @@ export enum ScenesActionType {
   CLOSE_ZIP_CONTENTS = '[Scenes] Close Zip Contents',
 
   ADD_CMR_DATA_TO_ON_DEMAND_JOBS = '[Scenes] Add CMR Data to On Demand Jobs',
+  UPDATE_PRODUCT_WITH_NEW_PROJECT_NAME = '[Scenes] Update proudct with new project name',
 
   SET_SELECTED_SCENE = '[Scenes] Set Selected Scene',
   SET_SELECTED_PAIR = '[Scenes] Set Selected Pair',
@@ -190,6 +192,12 @@ export class AddCmrDataToOnDemandScenes implements Action {
   constructor(public payload: CMRProductsById) {}
 }
 
+export class UpdateProductWithNewProjectName implements Action {
+  public readonly type = ScenesActionType.UPDATE_PRODUCT_WITH_NEW_PROJECT_NAME;
+
+  constructor(public payload: { productId: string; name: string }) {}
+}
+
 export type ScenesActions =
   | SetScenes
   | ClearScenes
@@ -214,4 +222,5 @@ export type ScenesActions =
   | SetSarviewsEventProducts
   | SetSelectedSarviewProduct
   | AddCmrDataToOnDemandScenes
+  | UpdateProductWithNewProjectName
   | SetImageBrowseProducts;

--- a/src/app/store/scenes/scenes.reducer.ts
+++ b/src/app/store/scenes/scenes.reducer.ts
@@ -184,6 +184,26 @@ export function scenesReducer(
       }
     }
 
+    case ScenesActionType.UPDATE_PRODUCT_WITH_NEW_PROJECT_NAME: {
+      const { productId, name } = action.payload;
+      const products = { ...state.products };
+
+      const toUpdate = products[productId];
+
+      products[productId] = {
+        ...toUpdate,
+        metadata: {
+        ...toUpdate.metadata,
+        job: {
+          ...toUpdate.metadata.job,
+          name,
+        },
+        },
+      };
+
+      return { ...state, products };
+    }
+
     case ScenesActionType.SET_SELECTED_SCENE: {
       return {
         ...state,

--- a/src/app/store/scenes/scenes.reducer.ts
+++ b/src/app/store/scenes/scenes.reducer.ts
@@ -193,11 +193,11 @@ export function scenesReducer(
       products[productId] = {
         ...toUpdate,
         metadata: {
-        ...toUpdate.metadata,
-        job: {
-          ...toUpdate.metadata.job,
-          name,
-        },
+          ...toUpdate.metadata,
+          job: {
+            ...toUpdate.metadata.job,
+            name,
+          },
         },
       };
 


### PR DESCRIPTION
## Summary
Add buttons for on demand job project renaming. Just a rough update to have something for tools to test.

## Note 
Uses `/jobs` patch enpoint is currently available in https://hyp3-api.asf.alaska.edu/

## TODO:

- [x] Test bulk update with 1000s of jobs
- [ ] Some way to limit/handle bulk rename in scene list header (will happily rename thousands of jobs, which could blow away all of your project names)
- [ ] Update job names on bulk update (currently need to reload on demand search to see new job name) 
- [ ] Update UI to look better for single and bulk rename
- [ ] Add keys for translation
- [ ] Maybe loading spinner/bar for renaming large numbers of jobs
