### PR TITLE
DS-6220 Remove file type filter for ARIA S1 GUNW

### DIFF
--- a/src/app/components/shared/selectors/product-type-selector/product-type-selector.component.html
+++ b/src/app/components/shared/selectors/product-type-selector/product-type-selector.component.html
@@ -1,3 +1,4 @@
+@if (!isAriaS1Gunw) {
 <mat-form-field>
   <mat-select
     [(value)]="productTypesList"
@@ -27,3 +28,4 @@
     </mat-hint>
   }
 </mat-form-field>
+}

--- a/src/app/components/shared/selectors/product-type-selector/product-type-selector.component.ts
+++ b/src/app/components/shared/selectors/product-type-selector/product-type-selector.component.ts
@@ -119,4 +119,9 @@ export class ProductTypeSelectorComponent implements OnInit, OnDestroy {
 
     this.typesChange.emit(productTypes);
   }
+
+  public get isAriaS1Gunw(): boolean {
+    return this.dataset?.apiValue?.dataset === 'ARIA S1 GUNW';
+  }
+
 }


### PR DESCRIPTION
## Summary
Removes the File Type filter from Additional Filters when the selected dataset is ARIA S1 GUNW, leaving only Beam Mode, Polarization, and Direction as intended for this dataset.