### PR TITLE
DS-6221 ARIA GUNW: Remove campaign selector filter

### DIFF
--- a/src/app/models/datasets/beta.ts
+++ b/src/app/models/datasets/beta.ts
@@ -12,7 +12,6 @@ export const beta = {
     Props.FRAME,
     Props.FLIGHT_DIRECTION,
     Props.POLARIZATION,
-    Props.MISSION_NAME,
     Props.ABSOLUTE_ORBIT,
     Props.FRAME_ORDERING,
     Props.BASELINE_TOOL,


### PR DESCRIPTION
## Summary
The campaign selector filter does not apply to ARIA GUNW.
