### PR TITLE
Max Results Hotfix

### DIFF
--- a/src/app/components/shared/max-results-selector/max-results-selector.component.ts
+++ b/src/app/components/shared/max-results-selector/max-results-selector.component.ts
@@ -52,7 +52,7 @@ export class MaxResultsSelectorComponent implements OnInit, OnDestroy {
 
   public burstXMLFileCount = 0;
 
-  public possibleMaxResults = [250, 1000];
+  public possibleMaxResults = [250, 500];
   private subs = new SubSink();
   constructor() {
     const library = inject(FaIconLibrary);


### PR DESCRIPTION
- Updates max results selector to max out at 500
   - Temporary until API improvements to fix large results breaking API Gateway
