### PR TITLE
NISAR default filters

### DIFF
--- a/e2e/geographic/default-filters.spec.ts
+++ b/e2e/geographic/default-filters.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test('NISAR default filter sticks around', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Sentinel-' }).click();
+  await page
+    .getByRole('menuitem', { name: 'NISAR (Uncalibrated) NISAR' })
+    .click();
+  await expect(page.locator('app-info-bar')).toContainText(
+    'Production Configuration: PR',
+  );
+  await page.locator('#mat-button-toggle-9-button').click();
+  await page.getByRole('menuitem', { name: 'Clear Search' }).click();
+  await expect(page.locator('app-info-bar')).toContainText(
+    'Production Configuration: PR',
+  );
+  await page.getByRole('button', { name: 'Filters', exact: true }).click();
+  await page
+    .locator('div')
+    .filter({ hasText: /^Production ConfigurationProduction$/ })
+    .first()
+    .click();
+  await page.getByRole('option', { name: 'Production' }).click();
+  await page.getByText('Urgent Response').click();
+  await page.locator('.cdk-overlay-backdrop').click();
+
+  await expect(page.locator('app-info-bar')).toContainText(
+    'Production Configuration: UR',
+  );
+  await page.locator('#mat-button-toggle-7-button').click();
+  await page.getByRole('menuitem', { name: 'Clear Search' }).click();
+  await expect(page.locator('app-info-bar')).toContainText(
+    'Production Configuration: PR',
+  );
+});

--- a/src/app/components/shared/selectors/production-config-selector/production-config-selector.component.ts
+++ b/src/app/components/shared/selectors/production-config-selector/production-config-selector.component.ts
@@ -33,7 +33,7 @@ export class ProductionConfigSelectorComponent implements OnInit, OnDestroy {
   private store$ = inject<Store<AppState>>(Store);
 
   prodConfigControl = new FormControl(['']);
-  public selectedConfig: string[] = ['PR']; // Default selected config
+  public selectedConfig: string[] = [];
 
   prodConfigs: prodConfig[] = [
     { value: 'PR', viewValue: 'PRODUCTION' },
@@ -44,8 +44,6 @@ export class ProductionConfigSelectorComponent implements OnInit, OnDestroy {
   private subs: SubSink = new SubSink();
 
   public ngOnInit(): void {
-    this.onProductionConfigSelect(this.selectedConfig);
-
     this.subs.add(
       this.store$
         .select(filtersStore.getProductionConfig)

--- a/src/app/models/dataset.model.ts
+++ b/src/app/models/dataset.model.ts
@@ -1,3 +1,4 @@
+import { FiltersState } from '@store/filters';
 import * as fromDatasets from './datasets';
 import { Props } from './filters.model';
 
@@ -8,6 +9,7 @@ export interface Dataset {
   beta: boolean;
   apiValue: Record<string, string>;
   date: DateRange;
+  defaultFilters?: Partial<FiltersState>;
   infoUrl: string;
   citationUrl: string;
   productTypes: ProductType[];

--- a/src/app/models/datasets/nisar.ts
+++ b/src/app/models/datasets/nisar.ts
@@ -23,6 +23,9 @@ export const nisar = {
   ],
   apiValue: { dataset: 'NISAR' },
   date: { start: new Date('2025/08/02 03:44:43 UTC') },
+  defaultFilters: {
+    productionConfig: ['PR'],
+  },
   infoUrl: 'https://nisar-docs.asf.alaska.edu/',
   citationUrl: 'https://asf.alaska.edu/nisar/',
   frequency: 'L-Band',

--- a/src/app/store/filters/filters.action.ts
+++ b/src/app/store/filters/filters.action.ts
@@ -2,6 +2,7 @@ import { Action } from '@ngrx/store';
 
 import * as models from '@models';
 import { EventProductSort, SBASOverlap } from '@models';
+import { FiltersState } from './filters.reducer';
 
 export enum FiltersActionType {
   SET_SELECTED_DATASET = '[Filters-Dataset] Set Selected Dataset',
@@ -111,6 +112,8 @@ export enum FiltersActionType {
   SET_ARIA_VERSION = '[Filters] Set ARIA Version',
 
   SET_USER_FRAME_FOR_BASELINE = '[Filters] Set if frame(s) used for baseline/sbas searches as reference scene',
+
+  APPLY_DATASET_DEFAULTS = '[Filters] Apply dataset default filters',
 }
 
 export class SetSelectedDataset implements Action {
@@ -443,6 +446,12 @@ export class SetDefaultFilters implements Action {
   ) {}
 }
 
+export class ApplyDatasetDefaults implements Action {
+  public readonly type = FiltersActionType.APPLY_DATASET_DEFAULTS;
+
+  constructor(public payload: Partial<FiltersState>) {}
+}
+
 export class SetGeocode implements Action {
   public readonly type = FiltersActionType.SET_GEOCODE;
 
@@ -605,4 +614,5 @@ export type FiltersActions =
   | setScienceProduct
   | setProductionConfig
   | setAriaVersion
-  | SetUseFrameForBaseline;
+  | SetUseFrameForBaseline
+  | ApplyDatasetDefaults;

--- a/src/app/store/filters/filters.effect.ts
+++ b/src/app/store/filters/filters.effect.ts
@@ -17,6 +17,7 @@ import { getSearchType } from '@store/search';
 import { LoadFiltersPreset } from '@store/user';
 import { ResetMaxHyp3ResultsHit } from '@store/hyp3';
 import { SearchType } from '@models';
+import { getSelectedDataset } from './filters.reducer';
 
 @Injectable()
 export class FiltersEffects {
@@ -74,6 +75,26 @@ export class FiltersEffects {
         filtersAction.FiltersActionType.SET_PROJECT_NAME,
       ),
       map((_) => new ResetMaxHyp3ResultsHit()),
+    ),
+  );
+
+  public applyDefaultFilters = createEffect(() =>
+    this.actions$.pipe(
+      ofType(
+        filtersAction.FiltersActionType.CLEAR_DATASET_FILTERS,
+        filtersAction.FiltersActionType.SET_SELECTED_DATASET,
+      ),
+      withLatestFrom(this.store$.select(getSelectedDataset)),
+      filter(([_, dataset]) => !!dataset),
+      map(([_, dataset]) => {
+        const defaults = dataset.defaultFilters;
+        if (!defaults) {
+          return null;
+        }
+
+        return new filtersAction.ApplyDatasetDefaults(defaults);
+      }),
+      filter((a) => a !== null),
     ),
   );
 }

--- a/src/app/store/filters/filters.reducer.ts
+++ b/src/app/store/filters/filters.reducer.ts
@@ -498,6 +498,13 @@ export function filtersReducer(
       return { ...state, shouldOmitSearchPolygon: false };
     }
 
+    case FiltersActionType.APPLY_DATASET_DEFAULTS: {
+      return {
+        ...state,
+        ...action.payload,
+      };
+    }
+
     case FiltersActionType.OMIT_SEARCH_POLYGON: {
       return { ...state, shouldOmitSearchPolygon: true };
     }


### PR DESCRIPTION
## Summary
Adds logic for re adding the default `productionConfig: ['PR']` that NISAR uses where it was going away before. Supports datasets in the future using similar functionality. 