### PR TITLE
Replace raw HTML in no results message with plain text and add Spanish

### DIFF
--- a/src/app/components/header/info-bar/ci-search/ci-search.component.ts
+++ b/src/app/components/header/info-bar/ci-search/ci-search.component.ts
@@ -1,4 +1,14 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import {
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  OnInit,
+  OnDestroy,
+  inject,
+} from '@angular/core';
+import { Store } from '@ngrx/store';
+import { AppState } from '@store';
+import * as uiStore from '@store/ui';
+import { SubSink } from 'subsink';
 
 @Component({
   selector: 'app-ci-search',
@@ -7,18 +17,92 @@ import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
   styleUrls: ['./ci-search.component.scss'],
   standalone: true,
 })
-export class CiSearchComponent {
+export class CiSearchComponent implements OnInit, OnDestroy {
+  private store$ = inject<Store<AppState>>(Store);
+  private subs = new SubSink();
+  private observer: MutationObserver;
+  private currentLang = 'en';
+
+  private noResultsTranslations: Record<string, string> = {
+    en: 'No results found. If you are searching for data, use Vertex at https://search.asf.alaska.edu',
+    es: 'No se encontraron resultados. Si está buscando datos, use Vertex en https://search.asf.alaska.edu',
+  };
+
   constructor() {
     this.showSearch();
+    this.observeNoResults();
+  }
+
+  ngOnInit() {
+    this.subs.add(
+      this.store$
+        .select(uiStore.getCurrentLanguage)
+        .subscribe((currentLanguage) => {
+          this.currentLang = currentLanguage || 'en';
+        }),
+    );
   }
 
   public showSearch() {
     const id = 'b8df7ea0-38a5-11eb-9b20-0242ac130002';
+
+    (window as any)._overwriting_er_config = {
+      lang: {
+        translations: {
+          en: {
+            common: {
+              no_results_found: this.noResultsTranslations['en'],
+            },
+          },
+          es: {
+            common: {
+              no_results_found: this.noResultsTranslations['es'],
+            },
+          },
+        },
+      },
+    };
+
     const ci_search = document.createElement('script');
     ci_search.type = 'text/javascript';
     ci_search.async = true;
     ci_search.src = 'https://cse.expertrec.com/api/js/ci_common.js?id=' + id;
     const s = document.getElementsByTagName('script')[0];
     s.parentNode.insertBefore(ci_search, s);
+  }
+
+  private observeNoResults() {
+    this.observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (node instanceof HTMLElement) {
+            this.replaceNoResultsText(node);
+          }
+        }
+      }
+    });
+
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  private replaceNoResultsText(element: HTMLElement) {
+    const text = element.textContent || '';
+    const hasRawHtml = text.includes('<div') || text.includes('<br>') || text.includes('<a href');
+    const hasNoResults = text.includes('No results found') || text.includes('Keine Ergebnisse') || text.includes('Ingen resultater');
+
+    if (hasRawHtml || hasNoResults) {
+      const translation = this.noResultsTranslations[this.currentLang] || this.noResultsTranslations['en'];
+      element.textContent = translation;
+    }
+  }
+
+  ngOnDestroy() {
+    this.subs.unsubscribe();
+    if (this.observer) {
+      this.observer.disconnect();
+    }
   }
 }

--- a/src/app/components/header/info-bar/ci-search/ci-search.component.ts
+++ b/src/app/components/header/info-bar/ci-search/ci-search.component.ts
@@ -90,11 +90,19 @@ export class CiSearchComponent implements OnInit, OnDestroy {
 
   private replaceNoResultsText(element: HTMLElement) {
     const text = element.textContent || '';
-    const hasRawHtml = text.includes('<div') || text.includes('<br>') || text.includes('<a href');
-    const hasNoResults = text.includes('No results found') || text.includes('Keine Ergebnisse') || text.includes('Ingen resultater');
+    const hasRawHtml =
+      text.includes('<div') ||
+      text.includes('<br>') ||
+      text.includes('<a href');
+    const hasNoResults =
+      text.includes('No results found') ||
+      text.includes('Keine Ergebnisse') ||
+      text.includes('Ingen resultater');
 
     if (hasRawHtml || hasNoResults) {
-      const translation = this.noResultsTranslations[this.currentLang] || this.noResultsTranslations['en'];
+      const translation =
+        this.noResultsTranslations[this.currentLang] ||
+        this.noResultsTranslations['en'];
       element.textContent = translation;
     }
   }


### PR DESCRIPTION
 ## Summary
Replace raw HTML in the Expertrec "no results" message with plain text.
Add a MutationObserver to dynamically replace the message based on the
current language (English/Spanish).

## Related Issues
DS-4626

## Screenshots / UI Changes


## i18n
- [x] No hardcoded user-facing strings
- [x] New or modified translation keys are documented below

### i18n keys changed/added
No i18n file keys added. Translations are handled internally in the
ci-search component via the Expertrec widget config override.
- en: "No results found. If you are searching for data, use Vertex at https://search.asf.alaska.edu"
- es: "No se encontraron resultados. Si está buscando datos, use Vertex en https://search.asf.alaska.edu"

## Tests & Build
- [x] `npm run lint` passes
- [ ] `npm test` passes (or N/A)
- [ ] `npm run build` succeeds
