### PR TITLE
User token fix

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -158,8 +158,13 @@ export class AuthService {
             user['exp'],
           );
         }),
-        map((final) => {
-          this.existingUserInfo = final;
+        map((user) => {
+          this.existingUserInfo = user;
+
+          if (this.isExpired(user)) {
+            return null;
+          }
+
           setTimeout(
             () => {
               this.store$.dispatch(new userStore.Logout());
@@ -168,9 +173,9 @@ export class AuthService {
                 'Please login again',
               );
             },
-            final.exp * 1000 - Date.now(),
+            user.exp * 1000 - Date.now(),
           );
-          return final;
+          return user;
         }),
         catchError((_error) => {
           console.error('Failed to get user info');
@@ -178,6 +183,10 @@ export class AuthService {
         }),
         take(1),
       );
+  }
+
+  private isExpired(userToken: models.UserAuth): boolean {
+    return Date.now() > userToken.exp * 1000;
   }
 
   private makeUser(

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -160,21 +160,19 @@ export class AuthService {
         }),
         map((user) => {
           this.existingUserInfo = user;
+          const expMs = user.exp * 1000;
 
-          if (this.isExpired(user)) {
+          if (this.isExpired(expMs)) {
             return null;
           }
+          setTimeout(() => {
+            this.store$.dispatch(new userStore.Logout());
+            this.notificationService.info(
+              'Session Expired',
+              'Please login again',
+            );
+          }, expMs - Date.now());
 
-          setTimeout(
-            () => {
-              this.store$.dispatch(new userStore.Logout());
-              this.notificationService.info(
-                'Session Expired',
-                'Please login again',
-              );
-            },
-            user.exp * 1000 - Date.now(),
-          );
           return user;
         }),
         catchError((_error) => {
@@ -185,8 +183,8 @@ export class AuthService {
       );
   }
 
-  private isExpired(userToken: models.UserAuth): boolean {
-    return Date.now() > userToken.exp * 1000;
+  private isExpired(expMs: number): boolean {
+    return Date.now() > expMs;
   }
 
   private makeUser(


### PR DESCRIPTION
## Summary
Users were still auto logging in with an expired cookie. We had logic for this in the past, but it got removed unintentionally. This was the [previous implementation](https://github.com/asfadmin/Discovery-SearchUI/blob/024a241af73409c8cc24987a56d6ec6e9a990015/src/app/services/auth.service.ts#L163) that's been ported over in this PR
