### PR TITLE
Fix user info URL on hyp3 whitelist functioanlity

### DIFF
--- a/src/app/services/user-data.service.ts
+++ b/src/app/services/user-data.service.ts
@@ -118,6 +118,6 @@ export class UserDataService {
     return this.env.currentEnv.user_data;
   }
   public getUserInfoURL(baseUrl: string): string {
-    return `${baseUrl}/info/`;
+    return `${baseUrl}/info`;
   }
 }


### PR DESCRIPTION
## Summary
The user data service url pathing changed disallowing the slash at the end of the URL. Fixes to get that part of the form to load in successfully
