### PR TITLE
Catch SBAS search errors when granule doesn't have baseline

### DIFF
--- a/src/app/components/shared/search-button/search-button.component.ts
+++ b/src/app/components/shared/search-button/search-button.component.ts
@@ -106,7 +106,7 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
   );
 
   public isLoggedIn = false;
-  public searchError$ = new Subject<void>();
+  public searchError$ = new Subject<searchStore.SearchError>();
   public isSearchError = false;
   public isFiltersOpen = false;
 
@@ -142,7 +142,7 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
             searchStore.SearchActionType.SEARCH_ERROR,
           ),
         )
-        .subscribe((_) => this.onSearchError()),
+        .subscribe((error) => this.onSearchError(error)),
     );
 
     this.subs.add(
@@ -220,13 +220,11 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
     this.subs.add(
       this.searchError$
         .pipe(
-          tap((_) => {
+          tap((error) => {
+            const errorMessage =
+              error.payload || 'Trouble loading search results';
             this.isSearchError = true;
-            this.notificationService.error(
-              'Trouble loading search results',
-              'Search Error',
-              { timeOut: 5000 },
-            );
+            this.notificationService.error(errorMessage, 'Search Error');
           }),
           delay(820),
         )
@@ -236,8 +234,8 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
     );
   }
 
-  public onSearchError(): void {
-    this.searchError$.next();
+  public onSearchError(error: searchStore.SearchError): void {
+    this.searchError$.next(error);
   }
 
   public saveCurrentSearch(): void {

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -3,7 +3,7 @@ import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, Action } from '@ngrx/store';
 
-import { of, forkJoin, combineLatest, Observable, EMPTY } from 'rxjs';
+import { of, forkJoin, combineLatest, Observable } from 'rxjs';
 import {
   map,
   withLatestFrom,
@@ -198,11 +198,21 @@ export class SearchEffects {
           return this.customProductsQuery$();
         } else if (searchType === SearchType.DISPLACEMENT) {
           return this.timeseriesQuery$();
+        } else {
+          this.logCountries();
+          return this.asfApiQuery$;
+        }
+      }),
+      catchError((err: HttpErrorResponse) => {
+        const errorMsg = err?.error?.error?.report;
+        if (errorMsg) {
+          return of(new SearchError(errorMsg));
+        }
+        if (err.status !== 400) {
+          return of(new SearchError('Unknown Error'));
         }
 
-        this.logCountries();
-
-        return this.asfApiQuery$;
+        return of(new SearchError('Error loading search results'));
       }),
     ),
   );
@@ -599,12 +609,6 @@ export class SearchEffects {
               })
             : new SearchCanceled(),
         ),
-        catchError((err: HttpErrorResponse) => {
-          if (err.status !== 400) {
-            return of(new SearchError('Unknown Error'));
-          }
-          return EMPTY;
-        }),
       ),
     ),
   );
@@ -632,16 +636,6 @@ export class SearchEffects {
                 })
               : new SearchCanceled();
           }),
-          catchError((err: HttpErrorResponse) => {
-            const errorMsg = err?.error?.error?.report;
-            if (errorMsg) {
-              return of(new SearchError(errorMsg));
-            }
-            if (err.status !== 400) {
-              return of(new SearchError('Unknown Error'));
-            }
-            return EMPTY;
-          }),
         );
       }),
     );
@@ -666,10 +660,6 @@ export class SearchEffects {
             })
           : new SearchCanceled(),
       ),
-      catchError((error) => {
-        console.log(error);
-        return of(new SearchError('Error loading search results'));
-      }),
     );
   }
 

--- a/src/app/store/search/search.effect.ts
+++ b/src/app/store/search/search.effect.ts
@@ -633,6 +633,10 @@ export class SearchEffects {
               : new SearchCanceled();
           }),
           catchError((err: HttpErrorResponse) => {
+            const errorMsg = err?.error?.error?.report;
+            if (errorMsg) {
+              return of(new SearchError(errorMsg));
+            }
             if (err.status !== 400) {
               return of(new SearchError('Unknown Error'));
             }


### PR DESCRIPTION
## Summary
From Slack: I'm being frustrated by Vertex hanging when doing SBAS searches for recently-acquired S1 SLCs and bursts. Under the hood, the request to the search API is failing with "Search failed to find results: Requested reference scene has no baseline", which is reasonable. The UI is failing to handle the error properly; it sits with the progress bar spinning forever and never shows me an error message.

This also only happens if you make the search using the SBAS or Baseline button in geo/list. Otherwise the search button get's greyed out. 

## Tests & Build
- [ ] `npm run lint` passes
- [ ] `npm test` passes (or N/A)
- [ ] `npm run build` succeeds

## Notes
Updated search errors so they are caught in makeSearch so searches can't fail and not be caught in different search types.

Also added feature to show the error message to the user if there is one (only tested for "Search failed to find results: Requested reference scene has no baseline" error message).