### PR TITLE
Reset validate only default

### DIFF
--- a/src/app/components/header/processing-queue/confirmation/confirmation.component.ts
+++ b/src/app/components/header/processing-queue/confirmation/confirmation.component.ts
@@ -147,7 +147,7 @@ export class ConfirmationComponent implements OnInit {
 
     this.isQueueSubmitProcessing = true;
     this.progress = 0;
-    this.validateOnly = true;
+    this.validateOnly = false;
 
     from(hyp3JobRequestBatches)
       .pipe(


### PR DESCRIPTION
## Summary
Hyp3 job submissions are defaulting to validate only not allowing anyone to submit jobs.

