### PR TITLE
feat: Add a validate only selector for testing in customize

### DIFF
--- a/src/app/components/header/header-buttons/customize-env/customize-env.component.html
+++ b/src/app/components/header/header-buttons/customize-env/customize-env.component.html
@@ -3,6 +3,14 @@
 </div>
 
 <mat-dialog-content class="h100 w100">
+  <mat-slide-toggle
+    style="margin-right: 16px; padding-bottom: 16px"
+    (change)="onValidateOnlyToggle($event.checked)"
+    [(ngModel)]="env.validateOnlyHyp3"
+  >
+  Validate Only HyP3
+  </mat-slide-toggle>
+
   <form #envForm="ngForm">
     <mat-form-field class="w100">
       <mat-label>{{ 'ENVIRONMENT_FILE' | translate }}</mat-label>

--- a/src/app/components/header/header-buttons/customize-env/customize-env.component.ts
+++ b/src/app/components/header/header-buttons/customize-env/customize-env.component.ts
@@ -12,6 +12,7 @@ import { MatFormField, MatLabel, MatInput } from '@angular/material/input';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { MatButton } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
 
 @Component({
   selector: 'app-customize-env',
@@ -32,10 +33,11 @@ import { TranslateModule } from '@ngx-translate/core';
     MatDialogActions,
     MatButton,
     TranslateModule,
+    MatSlideToggle,
   ],
 })
 export class CustomizeEnvComponent implements OnInit {
-  private env = inject(EnvironmentService);
+  public env = inject(EnvironmentService);
   private notificationService = inject(NotificationService);
 
   public envStr: string;
@@ -77,5 +79,9 @@ export class CustomizeEnvComponent implements OnInit {
     localStorage.removeItem('customEnv-1');
     this.env.resetToDefault();
     this.envStr = JSON.stringify(this.env.envs, null, 2);
+  }
+
+  public onValidateOnlyToggle(validateOnly: boolean) {
+    this.env.validateOnlyHyp3 = validateOnly;
   }
 }

--- a/src/app/components/header/processing-queue/confirmation/confirmation.component.ts
+++ b/src/app/components/header/processing-queue/confirmation/confirmation.component.ts
@@ -147,7 +147,6 @@ export class ConfirmationComponent implements OnInit {
 
     this.isQueueSubmitProcessing = true;
     this.progress = 0;
-    this.validateOnly = false;
 
     from(hyp3JobRequestBatches)
       .pipe(

--- a/src/app/components/header/processing-queue/processing-queue.component.html
+++ b/src/app/components/header/processing-queue/processing-queue.component.html
@@ -491,7 +491,7 @@
         <mat-slide-toggle
           style="margin-right: 16px"
           (change)="onValidateOnlyToggle($event.checked)"
-          [(ngModel)]="validateOnly"
+          [(ngModel)]="env.validateOnlyHyp3"
         >
           {{ 'VALIDATE_ONLY' | translate }}
         </mat-slide-toggle>

--- a/src/app/components/header/processing-queue/processing-queue.component.ts
+++ b/src/app/components/header/processing-queue/processing-queue.component.ts
@@ -131,7 +131,6 @@ export class ProcessingQueueComponent implements OnInit {
 
   public projectName = '';
   public processingOptions: models.Hyp3ProcessingOptions;
-  public validateOnly = false;
 
   public hyp3JobTypes = models.hyp3JobTypes;
   public hyp3JobTypesList: models.Hyp3JobType[];
@@ -306,7 +305,7 @@ export class ProcessingQueueComponent implements OnInit {
         jobTypesWithQueued: this.jobTypesWithQueued,
         projectName: this.projectName,
         processingOptions: this.processingOptions,
-        validateOnly: this.validateOnly,
+        validateOnly: this.env.validateOnlyHyp3,
       },
     });
 
@@ -316,7 +315,7 @@ export class ProcessingQueueComponent implements OnInit {
       }
 
       if (this.env.maturity === 'prod') {
-        this.validateOnly = false;
+        this.env.validateOnlyHyp3 = false;
       }
 
       this.onSubmitQueue();
@@ -454,7 +453,7 @@ export class ProcessingQueueComponent implements OnInit {
   }
 
   public onValidateOnlyToggle(val: boolean): void {
-    this.validateOnly = val;
+    this.env.validateOnlyHyp3 = val;
   }
 
   private selectDefaultJobType(): void {

--- a/src/app/services/environment.service.ts
+++ b/src/app/services/environment.service.ts
@@ -37,6 +37,7 @@ export class EnvironmentService {
   public envs: Environments;
   public maturity: string;
   public isProd: boolean;
+  public validateOnlyHyp3 = false;
 
   constructor() {
     this.isProd = env.defaultEnv === 'prod';


### PR DESCRIPTION
## Summary
Add a validate only slider in the env customization dialog so it can be enabled during prod environment mode. Move the validateOnly value into env service.
