### PR TITLE
Baseline/SBAS Saved Search and history

### DIFF
--- a/e2e/baseline/history.spec.ts
+++ b/e2e/baseline/history.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from 'e2e/pages/auth.page';
+
+test('Baseline: Search History', { tag: '@auth' }, async ({ loggedInPage }) => {
+  await loggedInPage.goto('/');
+  await loggedInPage.getByRole('button', { name: 'Geographic Search' }).click();
+  await loggedInPage
+    .getByRole('menuitem', { name: 'Baseline Baseline search' })
+    .click();
+
+  await loggedInPage
+    .getByRole('region', { name: 'Scene' })
+    .getByLabel('Scene')
+    .fill(
+      'S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C',
+    );
+  await loggedInPage
+    .locator('#mat-button-toggle-6-button')
+    .getByRole('button', { name: 'SEARCH' })
+    .click();
+  await loggedInPage
+    .getByRole('button', { name: 'automatedtesting_fullaccess' })
+    .click();
+  await loggedInPage.getByRole('menuitem', { name: 'Search History' }).click();
+  await loggedInPage.getByText('keyboard_arrow_right').click();
+  await expect(
+    loggedInPage.locator('app-baseline-search-filters'),
+  ).toContainText(
+    'Reference: S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C',
+  );
+});

--- a/e2e/baseline/save.spec.ts
+++ b/e2e/baseline/save.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from 'e2e/pages/auth.page';
+
+test('Baseline: Saved Search', { tag: '@auth' }, async ({ loggedInPage }) => {
+  await loggedInPage.goto('/');
+  await loggedInPage.getByRole('button', { name: 'Geographic Search' }).click();
+  await loggedInPage
+    .getByRole('menuitem', { name: 'Baseline Baseline search' })
+    .click();
+
+  await loggedInPage
+    .getByRole('region', { name: 'Scene' })
+    .getByLabel('Scene')
+    .fill(
+      'S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C',
+    );
+  await loggedInPage
+    .locator('#mat-button-toggle-6-button')
+    .getByRole('button', { name: 'SEARCH' })
+    .click();
+  await loggedInPage.locator('#mat-button-toggle-11-button').click();
+  await loggedInPage.getByRole('menuitem', { name: 'Saved Searches' }).click();
+  await loggedInPage.getByRole('menuitem', { name: 'Save Search' }).click();
+
+  await loggedInPage
+    .getByRole('textbox', { name: 'Save Search Name' })
+    .fill('test');
+  await loggedInPage.getByRole('button', { name: 'Save Search' }).click();
+  await loggedInPage.getByText('keyboard_arrow_right').click();
+  await expect(
+    loggedInPage.locator('app-baseline-search-filters'),
+  ).toContainText(
+    'Reference: S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C',
+  );
+});

--- a/e2e/pages/auth.page.ts
+++ b/e2e/pages/auth.page.ts
@@ -48,7 +48,7 @@ export const test = base.extend<{ loggedInPage: Page }>({
         }),
       });
     });
-    await page.route('**/services/search/param**', async (route) => {
+    await page.route('**/services/search/**', async (route) => {
       const url = new URL(route.request().url());
 
       // remove the fake cmr_token

--- a/e2e/sbas/history.spec.ts
+++ b/e2e/sbas/history.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from 'e2e/pages/auth.page';
+
+test('SBAS: Search History', { tag: '@auth' }, async ({ loggedInPage }) => {
+  await loggedInPage.goto('/');
+  await loggedInPage.getByRole('button', { name: 'Geographic Search' }).click();
+  await loggedInPage
+    .getByRole('menuitem', { name: 'SBAS SBAS search provides' })
+    .click();
+
+  await loggedInPage
+    .getByRole('region', { name: 'Scene' })
+    .getByLabel('Scene')
+    .fill(
+      'S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C',
+    );
+  await loggedInPage
+    .locator('#mat-button-toggle-6-button')
+    .getByRole('button', { name: 'SEARCH' })
+    .click();
+  await loggedInPage
+    .getByRole('button', { name: 'automatedtesting_fullaccess' })
+    .click();
+  await loggedInPage.getByRole('menuitem', { name: 'Search History' }).click();
+  await loggedInPage.getByText('keyboard_arrow_right').click();
+  await expect(loggedInPage.locator('app-sbas-search-filters')).toContainText(
+    'Reference: S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C',
+  );
+});

--- a/e2e/sbas/save.spec.ts
+++ b/e2e/sbas/save.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from 'e2e/pages/auth.page';
+
+test('SBAS: Saved Search', { tag: '@auth' }, async ({ loggedInPage }) => {
+  await loggedInPage.goto('/');
+  await loggedInPage.getByRole('button', { name: 'Geographic Search' }).click();
+  await loggedInPage
+    .getByRole('menuitem', { name: 'SBAS SBAS search provides' })
+    .click();
+
+  await loggedInPage
+    .getByRole('region', { name: 'Scene' })
+    .getByLabel('Scene')
+    .fill(
+      'S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C',
+    );
+  await loggedInPage
+    .locator('#mat-button-toggle-6-button')
+    .getByRole('button', { name: 'SEARCH' })
+    .click();
+  await loggedInPage.locator('#mat-button-toggle-11-button').click();
+  await loggedInPage.getByRole('menuitem', { name: 'Saved Searches' }).click();
+  await loggedInPage.getByRole('menuitem', { name: 'Save Search' }).click();
+
+  await loggedInPage
+    .getByRole('textbox', { name: 'Save Search Name' })
+    .fill('test');
+  await loggedInPage.getByRole('button', { name: 'Save Search' }).click();
+  await loggedInPage.getByText('keyboard_arrow_right').click();
+  await expect(loggedInPage.locator('app-sbas-search-filters')).toContainText(
+    'Reference: S1B_IW_SLC__1SDV_20210704T135937_20210704T140004_027645_034CB0_4B2C',
+  );
+});


### PR DESCRIPTION
## Summary
Adds tests using the new auth mock functionality for testing saved searches and history. The tests do a search, but don't need to wait for them to finish to use the functionality so they run pretty fast.

There was a small bug where the fake CMR token was only being filtered out for geo searches, should now handle all of our searches fine.