### PR TITLE
Filter S3 URIs from OPERA dataset Browse Image Viewer

### DIFF
--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -241,7 +241,9 @@ export class ProductService {
     if (s3Index !== -1) {
       product.metadata.s3URI = product.metadata.opera.s3Urls[s3Index];
     }
-    product.browses = product.browses.filter((url) => !url.includes('low-res'));
+    product.browses = product.browses.filter(
+      (url) => !url.includes('low-res') && !url.startsWith('s3'),
+    );
 
     for (const p of product.metadata.opera.additionalUrls.filter(
       (url) => url !== product.downloadUrl,


### PR DESCRIPTION
This also seems to have been an issue for the OPERA dataset in general, this PR should fix it for all OPERA results