### PR TITLE
feat: Add product files sizes to opera products

### DIFF
--- a/src/app/components/results-menu/scene-files/scene-file/scene-file.component.html
+++ b/src/app/components/results-menu/scene-files/scene-file/scene-file.component.html
@@ -104,7 +104,9 @@
       <span>{{ 'VIRTUAL' | translate }}</span>
     }
     @if (isDownloadable(product) && product.bytes !== 0) {
-      <span>{{ product.bytes.toString() | readableSizeFromBytes }}</span>
+      <span>
+        {{ product.bytes.toString() | readableSizeFromBytes }}
+      </span>
     }
   </div>
 

--- a/src/app/models/cmr-product.model.ts
+++ b/src/app/models/cmr-product.model.ts
@@ -96,6 +96,13 @@ export interface SLCBurstMetadata {
   subswath: string;
 }
 
+export interface OperaFileEntry {
+  bytes: number;
+  format: string;
+}
+
+export type OperaBytes = Record<string, OperaFileEntry>;
+
 export interface OperaS1Metadata {
   operaBurstID: string;
   additionalUrls: string[];
@@ -103,6 +110,7 @@ export interface OperaS1Metadata {
   validityStartDate?: moment.Moment | null;
   tileID?: string;
   productVersion?: string;
+  bytes: OperaBytes;
 }
 
 export interface NISARMetadata {

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -58,6 +58,10 @@ export class ProductService {
       };
 
       product.metadata.subproducts = this.getSubproducts(product);
+      if (product.metadata?.opera) {
+        product.bytes =
+          product?.metadata?.opera?.bytes?.[product.file]?.bytes || 0;
+      }
 
       return product;
     });
@@ -295,6 +299,10 @@ export class ProductService {
         0,
         [],
       );
+
+      subproduct.bytes =
+        subproduct?.metadata?.opera?.bytes?.[subproduct.file]?.bytes || 0;
+
       products.push(subproduct);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,7 +150,7 @@ bootstrapApplication(AppComponent, {
       }),
     ),
     provideTranslateService({
-      defaultLanguage: 'en',
+      fallbackLang: 'en',
       loader: {
         provide: TranslateLoader,
         useClass: StaticTranslateLoader,


### PR DESCRIPTION
## Summary
Add file sizes to opera products. Requires this [asf_search pr](https://github.com/asfadmin/Discovery-asf_search/pull/451), but will work regardless of if feature is deployed.

## Related Issues
fixes #1940

## Screenshots / UI Changes
With udpated asf_search running locally

<img width="1435" height="790" alt="image" src="https://github.com/user-attachments/assets/3b264f5c-15ce-4028-8147-d32cc7590eb8" />

## i18n
- [ ] No hardcoded user-facing strings
- [ ] New or modified translation keys are documented below

## Tests & Build
- [ ] `npm run lint` passes
- [ ] `npm test` passes (or N/A)
- [ ] `npm run build` succeeds
