### PR TITLE
Fix playwright auth tests

### DIFF
--- a/e2e/pages/auth.page.ts
+++ b/e2e/pages/auth.page.ts
@@ -37,12 +37,20 @@ export const test = base.extend<{ loggedInPage: Page }>({
       theme: 'light',
     });
     await page.route('**appdata**/info/cookie', async (route) => {
+      const current_date = new Date();
+      const future_date = new Date(
+        // 20 days in the future
+        current_date.setDate(current_date.getDate() + 20),
+      ).getTime();
       route.fulfill({
         body: JSON.stringify({
           exp: 2978525424,
           // fake token with just expiration date in it
-          'urs-access-token':
-            'eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNzc4MDExOTc4LCJleHAiOjI5Nzg1MjU0MjR9.',
+          'urs-access-token': `a.${btoa(
+            JSON.stringify({
+              exp: future_date,
+            }),
+          )}`,
           'urs-groups': [],
           'urs-user-id': 'automatedtesting_fullaccess',
         }),

--- a/e2e/pages/auth.page.ts
+++ b/e2e/pages/auth.page.ts
@@ -42,7 +42,7 @@ export const test = base.extend<{ loggedInPage: Page }>({
           exp: 2978525424,
           // fake token with just expiration date in it
           'urs-access-token':
-            'eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNzc4MDExOTc4LCJleHAiOjk5OTk5OTk5OTl9.',
+            'eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNzc4MDExOTc4LCJleHAiOjI5Nzg1MjU0MjR9.',
           'urs-groups': [],
           'urs-user-id': 'automatedtesting_fullaccess',
         }),

--- a/e2e/profile/login-state-sync.spec.ts
+++ b/e2e/profile/login-state-sync.spec.ts
@@ -1,61 +1,37 @@
-import { test, expect } from 'e2e/fixtures';
+import { test, expect } from 'e2e/pages/auth.page';
 
-test('Profile: login state is synced across instances', async ({ page }) => {
+test('Profile: login state is synced across instances', async ({
+  loggedInPage,
+}) => {
   let loggedIn = false;
 
-  await page.route('**appdata**/**/Profile', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        defaultDataset: 'SENTINEL-1',
-        defaultFilterPresets: {
-          'Baseline Search': '',
-          'Geographic Search': '',
-          'SBAS Search': '',
-          Displacement: '',
-        },
-        defaultMaxConcurrentDownloads: 3,
-        hyp3BackendUrl: 'https://hyp3-api.asf.alaska.edu',
-        hyp3SavedUrls: ['https://hyp3-api.asf.alaska.edu'],
-        language: 'en',
-        mapLayer: 'Satellite',
-        maxResults: 250,
-        theme: 'light',
-      }),
-    });
+  await loggedInPage.route('**appdata**/info/cookie', async (route) => {
+    if (!loggedIn) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(JSON.stringify({})),
+      });
+    } else {
+      route.fallback();
+    }
   });
 
-  await page.route('**appdata**/info/cookie', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(
-        loggedIn
-          ? {
-              exp: 2978525424,
-              'urs-access-token':
-                'eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNzc4MDExOTc4LCJleHAiOjk5OTk5OTk5OTl9.',
-              'urs-groups': [],
-              'urs-user-id': 'automatedtesting_fullaccess',
-            }
-          : {},
-      ),
-    });
-  });
+  await loggedInPage.goto('/');
 
-  await page.goto('/');
-
-  await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+  await expect(
+    loggedInPage.getByRole('button', { name: 'Sign In' }),
+  ).toBeVisible();
 
   loggedIn = true;
 
-  await page.evaluate(() => {
+  await loggedInPage.evaluate(() => {
     const bc = new BroadcastChannel('asf-vertex');
     bc.postMessage({ event: 'login' });
     bc.close();
   });
 
-  await expect(page.getByRole('button', { name: 'automatedtesting_fullaccess' }))
-    .toBeVisible();
+  await expect(
+    loggedInPage.getByRole('button', { name: 'automatedtesting_fullaccess' }),
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
Updates the fake Earthdata login JWT to instead be constantly 20 days in the future. This helps mitigate the issue of setTimeout firing off instantly