### PR TITLE
test: ensure even if tests fail that updated snapshots are still written

### DIFF
--- a/.github/workflows/update-snapshots.yaml
+++ b/.github/workflows/update-snapshots.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install angular cli
         run: npm install -g @angular/cli
       - name: Start server and record snapshots
-        run: ng serve --host=127.0.0.1 & npx wait-on http://127.0.0.1:4200 && npx playwright test --update-snapshots --reporter=list
+        run: ng serve --host=127.0.0.1 & npx wait-on http://127.0.0.1:4200 && npx playwright test --update-snapshots --reporter=list || true
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: '[CI] Update Snapshots'
+          commit_message: "[CI] Update Snapshots"


### PR DESCRIPTION
## Summary
update-snapshots github action fails due to tests failing even though valid snapshots are written! this adds an || true  so that it continues to commit changes even on failed tests.
