### PR TITLE
Update .gitignore to ignore non-linux screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ docs/
 /playwright-report/
 /playwright/.cache/
 playwright/
+
+# End to end snapshots
+# Non-ci
+e2e/**/*.png
+# CI
+!e2e/**/*-linux.png


### PR DESCRIPTION
### Description
This lets us keep screenshot tests locally without having to manage weird git workflows to keep things coherent.