### PR TITLE
Remove node modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@angular/platform-browser-dynamic": "^21.2.9",
         "@angular/router": "^21.2.9",
         "@babel/core": "^7.14.2",
-        "@formatjs/intl-displaynames": "^6.2.6",
         "@fortawesome/angular-fontawesome": "^4.0.0",
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.2.0",
@@ -2829,47 +2828,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
-      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.2",
-        "decimal.js": "^10.4.3",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.8.13",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.13.tgz",
-      "integrity": "sha512-VbY7BdYJX5eURVKLk2grndUQtnbCLNbcJId/Sb/PsX7fWXiqWvg7qt/mecVHRzqoSEoGCQToKDxzpJj8RC0s3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/intl-localematcher": "0.6.2",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
-      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@fortawesome/angular-fontawesome": {
@@ -8649,6 +8607,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-extend": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@angular/platform-browser-dynamic": "^21.2.9",
     "@angular/router": "^21.2.9",
     "@babel/core": "^7.14.2",
-    "@formatjs/intl-displaynames": "^6.2.6",
     "@fortawesome/angular-fontawesome": "^4.0.0",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,7 +1,3 @@
-import '@formatjs/intl-displaynames/polyfill';
-import '@formatjs/intl-displaynames/locale-data/en';
-import '@formatjs/intl-displaynames/locale-data/es';
-
 import { Component, Input, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';

--- a/src/app/components/shared/selectors/language-selector/language-selector.component.ts
+++ b/src/app/components/shared/selectors/language-selector/language-selector.component.ts
@@ -1,7 +1,3 @@
-import '@formatjs/intl-displaynames/polyfill';
-import '@formatjs/intl-displaynames/locale-data/en';
-import '@formatjs/intl-displaynames/locale-data/es';
-
 import { Component, Input, OnInit, inject } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { AsfLanguageService } from '@services/asf-language.service';

--- a/src/app/components/timeseries-chart/timeseries-chart.component.ts
+++ b/src/app/components/timeseries-chart/timeseries-chart.component.ts
@@ -39,7 +39,7 @@ import * as uiStore from '@store/ui';
 // import {hidden} from '@services/map/polygon.style';
 // import {style} from '@angular/animations';
 import { linearRegression, linearRegressionLine } from './regression-line';
-import { types } from 'sass';
+
 import { NgStyle } from '@angular/common';
 import { MatButton } from '@angular/material/button';
 import { ResizedDirective } from '../../directives/resized.directive';
@@ -1051,6 +1051,5 @@ export class TimeseriesChartComponent implements OnInit, OnDestroy {
   protected readonly Date = Date;
 
   protected readonly length = length;
-  protected readonly types = types;
   protected readonly Number = Number;
 }

--- a/src/app/services/asf-language.service.ts
+++ b/src/app/services/asf-language.service.ts
@@ -1,7 +1,3 @@
-import '@formatjs/intl-displaynames/polyfill';
-import '@formatjs/intl-displaynames/locale-data/en';
-import '@formatjs/intl-displaynames/locale-data/es';
-
 import { TranslateService } from '@ngx-translate/core';
 import { CookieService } from 'ngx-cookie-service';
 import * as moment from 'moment';


### PR DESCRIPTION
## Summary
Reduce bundle size and security footprint

## Notes

**Removed**
- @formatjs/intl-displaynames: Used for polyfill that browsers now just support
- sass import in timeseries chart. Added it to the bundle (3.1mb) for no apparent reason