### PR TITLE
security: increase npm dependency cooldown to 7 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=2
+min-release-age=7


### PR DESCRIPTION
## Summary
Increases the dependency cooldown in the npmrc to 7 days from 2 to mitigate supply chain attacks. We may also want to consider increasing the dependabot cooldown as well which skips the cooldown period for security fixes related to zero day vulnerabilities.