### PR TITLE
Remove false from queue all burst products

### DIFF
--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
@@ -421,7 +421,6 @@
                         : (burstMetadataProducts$ | async),
                   }"
                 >
-                  {{ isBurstStack$ | async }}
                   {{
                     searchType !== SearchTypes.SBAS
                       ? downloadableProds.length


### PR DESCRIPTION
## Summary
Fixes Tools-4576. SLC Burst bulk Queue button menu option typo

## Screenshots / UI Changes
Before:
<img width="749" height="380" alt="image" src="https://github.com/user-attachments/assets/e35eb986-5729-452b-a5ff-cd159c0e42a9" />

After:
<img width="709" height="380" alt="image" src="https://github.com/user-attachments/assets/a0e440f6-dccb-41ee-99ca-e68b4b93cbd9" />
