### PR TITLE
Cleanup Test

### DIFF
--- a/src/app/components/header/header-buttons/preferences/preferences.component.ts
+++ b/src/app/components/header/header-buttons/preferences/preferences.component.ts
@@ -125,7 +125,7 @@ export class PreferencesComponent implements OnInit, OnDestroy {
     'SBAS Search': '',
     Displacement: '',
   };
-  public currentTheme = 'System Preferences';
+  public currentTheme = 'light';
   public currentFilterDisplayNames = {};
 
   private subs = new SubSink();

--- a/src/app/components/shared/project-name-dialog/project-name-dialog.component.scss
+++ b/src/app/components/shared/project-name-dialog/project-name-dialog.component.scss
@@ -68,7 +68,7 @@ app-project-name-dialog {
   }
 
   .projects-table-wrapper {
-    border: 1px solid rgba(0, 0, 0, 0.12);
+    border: 1px solid rgb(0, 0, 0, 0.12);
     border-radius: 4px;
     margin-bottom: 8px;
     overflow: hidden;
@@ -183,7 +183,7 @@ app-project-name-dialog {
       margin: 0;
       padding-left: 20px;
       font-size: 13px;
-      border: 1px solid rgba(0, 0, 0, 0.12);
+      border: 1px solid rgb(0, 0, 0, 0.12);
       border-radius: 4px;
       padding: 8px 8px 8px 28px;
 

--- a/src/app/store/user/user.reducer.ts
+++ b/src/app/store/user/user.reducer.ts
@@ -34,7 +34,7 @@ export const initState: UserState = {
     },
     hyp3BackendUrl: '',
     hyp3SavedUrls: [],
-    theme: 'System Preferences',
+    theme: 'light',
     language: '',
   },
   savedSearches: {

--- a/src/index.html
+++ b/src/index.html
@@ -63,6 +63,7 @@
         height: -webkit-fill-available;
         padding: 0;
         margin: 0;
+        width: 100vw;
       }
     </style>
     <!-- END NASA TopHat Code -->

--- a/src/styles/global/toast.scss
+++ b/src/styles/global/toast.scss
@@ -1,11 +1,16 @@
 @use "./asf-theme" as *;
 
+$mobile-breakpoint: 1130px; // Defined in screen-size service
 
 #toast-container {
-  top: 140px;
+  top: 170px;
   right: 10px;
   float: right;
   z-index: 9999; // Higher than dialog overlay (2000) to appear above download queue
+
+  @media (max-width: $mobile-breakpoint) {
+    top: 100px;
+  }
 }
 
 // toast style overrides
@@ -116,4 +121,3 @@
   color: $asf-blue;
   text-decoration: underline;
 }
-


### PR DESCRIPTION
## Summary
Cleanup issues in test to be ready for deployment.

## Screenshots / UI Changes
Fix tophat not taking up full screen during loading
<img width="1059" height="504" alt="Screenshot From 2026-07-17 12-22-47" src="https://github.com/user-attachments/assets/38d9a0b4-007e-4ada-b93b-5941141c1307" />

Fix banner positioning
<img width="392" height="308" alt="image" src="https://github.com/user-attachments/assets/ef389b18-c432-42ff-80a7-65c15666864c" />

## Notes
Also changed default theme back to 'light'. Currently you can't change theme unless you are logged, to add back system preferences we need to detach theme from user profiles. Also users profiles would get set to 'System Preference' event if they didn't select it.