### PR TITLE
Feature: bulk add scene files by file type group

### DIFF
--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.ts
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.ts
@@ -123,10 +123,16 @@ export class ScenesListHeaderComponent implements OnInit, OnDestroy {
     this.store$.select(scenesStore.getAllProducts).pipe(
       map((scenes: []) =>
         scenes.reduce((prev, curr: models.CMRProduct) => {
-          if (!prev[curr.productTypeDisplay]) {
-            prev[curr.productTypeDisplay] = [];
+          // Bucket by the dataset's file type group when one is defined, so the
+          // bulk add menu offers a few meaningful groups instead of one entry per
+          // file type. Products with no group (and datasets that define none) keep
+          // falling back to their individual product type.
+          const key = curr.productTypeGroup ?? curr.productTypeDisplay;
+
+          if (!prev[key]) {
+            prev[key] = [];
           }
-          prev[curr.productTypeDisplay].push(curr);
+          prev[key].push(curr);
 
           return prev;
         }, {}),


### PR DESCRIPTION
Groups the add by file type menu entries by the dataset's file type groups when they are defined (TOOL-4858).

The menu listed one entry per product type display, which is noisy for NISAR scenes. Products are now bucketed by `productTypeGroup` when available, so auxiliary files collapse into a few meaningful groups (Metadata, Visualizations) while the main science products keep their individual entries. Products with no group, and datasets that define none, fall back to their individual product type, so no other dataset changes.

Once #2666 lands its expanded group mappings, this menu picks them up automatically.