### PR TITLE
Feature: label NISAR products provisional or uncalibrated by CRID

### DIFF
--- a/e2e/geographic/default-filters.spec.ts
+++ b/e2e/geographic/default-filters.spec.ts
@@ -4,7 +4,7 @@ test('NISAR default filter sticks around', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('button', { name: 'Sentinel-' }).click();
   await page
-    .getByRole('menuitem', { name: 'NISAR NISAR' })
+    .getByRole('menuitem', { name: 'NISAR (Provisional) NISAR' })
     .click();
   await expect(page.locator('app-info-bar')).toContainText(
     'Production Configuration: PR',

--- a/e2e/geographic/default-filters.spec.ts
+++ b/e2e/geographic/default-filters.spec.ts
@@ -4,7 +4,7 @@ test('NISAR default filter sticks around', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('button', { name: 'Sentinel-' }).click();
   await page
-    .getByRole('menuitem', { name: 'NISAR (Uncalibrated) NISAR' })
+    .getByRole('menuitem', { name: 'NISAR NISAR' })
     .click();
   await expect(page.locator('app-info-bar')).toContainText(
     'Production Configuration: PR',

--- a/e2e/geographic/full-search.spec.ts
+++ b/e2e/geographic/full-search.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from 'e2e/fixtures';
 import { waitForASFAPIResponse } from 'e2e/helpers';
 
 [
-  { menuSelector: 'NISAR (Uncalibrated) NISAR', expected: 'NISAR' },
+  { menuSelector: 'NISAR NISAR', expected: 'NISAR' },
   { menuSelector: 'S1 Burst', expected: 'S1 Burst' },
   { menuSelector: 'OPERA-S1 Sentinel-1 RTC', expected: 'OPERA-S1' },
   { menuSelector: 'TROPO The Troposphere Zenith', expected: 'TROPO' },

--- a/e2e/geographic/full-search.spec.ts
+++ b/e2e/geographic/full-search.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from 'e2e/fixtures';
 import { waitForASFAPIResponse } from 'e2e/helpers';
 
 [
-  { menuSelector: 'NISAR NISAR', expected: 'NISAR' },
+  { menuSelector: 'NISAR (Provisional) NISAR', expected: 'NISAR' },
   { menuSelector: 'S1 Burst', expected: 'S1 Burst' },
   { menuSelector: 'OPERA-S1 Sentinel-1 RTC', expected: 'OPERA-S1' },
   { menuSelector: 'TROPO The Troposphere Zenith', expected: 'TROPO' },

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.html
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.html
@@ -44,12 +44,12 @@
         <span matTooltip="{{ 'FREQUENCY' | translate }}">
           {{ dataset.frequency }}
         </span>
-        @if (dataset.id === 'NISAR') {
+        @if (nisarCalibration(); as calibration) {
           <em class="uncalibrated"
             ><app-docs-modal
               class="info-text"
-              [text]="'(' + ('UNCALIBRATED' | translate) + ')'"
-              url="https://nisar-docs.asf.alaska.edu/product-known-issues/"
+              [text]="'(' + (calibration.label | translate) + ')'"
+              [url]="calibration.url"
             >
             </app-docs-modal>
           </em>

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.spec.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.spec.ts
@@ -79,4 +79,54 @@ describe('SceneDetailComponent', () => {
 
     expect(component.productTypeDocsUrl).toBeNull();
   });
+
+  describe('nisar calibration label', () => {
+    const selectNisarScene = (crid: string | null) => {
+      const scene = productFactory
+        .withBasicInfo('test-nisar-scene')
+        .withDatasetFull(nisar)
+        .withMetadata({
+          nisar: {
+            additionalUrls: [],
+            s3Urls: [],
+            frameCoverage: '',
+            jointObservation: '',
+            sideBandPolarization: [],
+            mainBandPolarization: [],
+            rangeBandwidth: '',
+            crid,
+          },
+        })
+        .build();
+
+      store.overrideSelector(scenesStore.getSelectedScene, scene);
+      store.refreshState();
+      fixture.detectChanges();
+    };
+
+    it.each([
+      ['X05010', 'UNCALIBRATED'],
+      ['X05022', 'UNCALIBRATED'],
+      ['X05023', 'PROVISIONAL'],
+      ['X06001', 'PROVISIONAL'],
+      [null, 'UNCALIBRATED'],
+    ])('labels NISAR scenes with crid %s as %s', (crid, label) => {
+      selectNisarScene(crid as string | null);
+
+      expect(component.nisarCalibration()?.label).toBe(label);
+    });
+
+    it('returns no label for non-NISAR scenes', () => {
+      const sentinelScene = productFactory
+        .withBasicInfo('test-sentinel-scene')
+        .withDatasetFull(sentinel_1)
+        .build();
+
+      store.overrideSelector(scenesStore.getSelectedScene, sentinelScene);
+      store.refreshState();
+      fixture.detectChanges();
+
+      expect(component.nisarCalibration()).toBeNull();
+    });
+  });
 });

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -13,8 +13,8 @@ import * as userStore from '@store/user';
 import * as models from '@models';
 import {
   calibratedCrid,
-  knownIssuesUrl,
-  preCalibrationKnownIssuesUrl,
+  provisionalIssuesUrl,
+  betaIssuesUrl,
 } from '@models/datasets/nisar';
 
 import {
@@ -102,8 +102,8 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
     );
 
     return crid >= calibratedCrid
-      ? { label: 'PROVISIONAL', url: knownIssuesUrl }
-      : { label: 'UNCALIBRATED', url: preCalibrationKnownIssuesUrl };
+      ? { label: 'PROVISIONAL', url: provisionalIssuesUrl }
+      : { label: 'UNCALIBRATED', url: betaIssuesUrl };
   }
 
   public isBrowseOverlayEnabled$: Observable<boolean> =

--- a/src/app/components/results-menu/scene-detail/scene-detail.component.ts
+++ b/src/app/components/results-menu/scene-detail/scene-detail.component.ts
@@ -11,6 +11,11 @@ import * as uiStore from '@store/ui';
 import * as userStore from '@store/user';
 
 import * as models from '@models';
+import {
+  calibratedCrid,
+  knownIssuesUrl,
+  preCalibrationKnownIssuesUrl,
+} from '@models/datasets/nisar';
 
 import {
   AuthService,
@@ -84,6 +89,22 @@ export class SceneDetailComponent implements OnInit, OnDestroy {
   public masterOffsets$ = this.store$.select(scenesStore.getMasterOffsets);
   public asfWebsite = models.asfWebsite;
   public productTypeDocsUrl: string | null = null;
+
+  // NISAR products processed with CRID 5023+ are provisional calibrated data;
+  // earlier CRIDs remain labelled uncalibrated with the pre-calibration docs
+  public nisarCalibration(): { label: string; url: string } | null {
+    if (this.dataset?.id !== 'NISAR') {
+      return null;
+    }
+
+    const crid = Number(
+      this.scene?.metadata?.nisar?.crid?.replace(/\D/g, '') ?? '',
+    );
+
+    return crid >= calibratedCrid
+      ? { label: 'PROVISIONAL', url: knownIssuesUrl }
+      : { label: 'UNCALIBRATED', url: preCalibrationKnownIssuesUrl };
+  }
 
   public isBrowseOverlayEnabled$: Observable<boolean> =
     this.browseOverlayService.isBrowseOverlayEnabled$;

--- a/src/app/components/shared/selectors/dataset-selector/dataset/dataset.component.html
+++ b/src/app/components/shared/selectors/dataset-selector/dataset/dataset.component.html
@@ -16,6 +16,15 @@
             <span><em> (beta) </em></span>
           }
 
+          @if (dataset.id === 'NISAR') {
+            <span>
+              <app-docs-modal
+                class="info-text"
+                [text]="'(' + ('PROVISIONAL' | translate) + ')'"
+                url="https://nisar-docs.asf.alaska.edu/product-known-issues/"
+              ></app-docs-modal
+            ></span>
+          }
           @if (dataset.subName) {
             <div class="dataset__subName faint-text">
               {{ dataset.subName }}

--- a/src/app/components/shared/selectors/dataset-selector/dataset/dataset.component.html
+++ b/src/app/components/shared/selectors/dataset-selector/dataset/dataset.component.html
@@ -21,7 +21,7 @@
               <app-docs-modal
                 class="info-text"
                 [text]="'(' + ('PROVISIONAL' | translate) + ')'"
-                url="https://nisar-docs.asf.alaska.edu/product-known-issues/"
+                [url]="provisionalIssuesUrl"
               ></app-docs-modal
             ></span>
           }

--- a/src/app/components/shared/selectors/dataset-selector/dataset/dataset.component.html
+++ b/src/app/components/shared/selectors/dataset-selector/dataset/dataset.component.html
@@ -16,15 +16,6 @@
             <span><em> (beta) </em></span>
           }
 
-          @if (dataset.id === 'NISAR') {
-            <span>
-              <app-docs-modal
-                class="info-text"
-                [text]="'(' + ('UNCALIBRATED' | translate) + ')'"
-                url="https://nisar-docs.asf.alaska.edu/product-known-issues/"
-              ></app-docs-modal
-            ></span>
-          }
           @if (dataset.subName) {
             <div class="dataset__subName faint-text">
               {{ dataset.subName }}

--- a/src/app/components/shared/selectors/dataset-selector/dataset/dataset.component.ts
+++ b/src/app/components/shared/selectors/dataset-selector/dataset/dataset.component.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 
 import { Dataset } from '@models';
+import { provisionalIssuesUrl } from '@models/datasets/nisar';
 import { MatIcon } from '@angular/material/icon';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -43,6 +44,8 @@ export class DatasetComponent {
   public breakpoint$ = this.screenSize.breakpoint$;
   public breakpoints = models.Breakpoints;
   @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
+
+  public provisionalIssuesUrl = provisionalIssuesUrl;
 
   public isReadMore = true;
   public onOpenHelp() {

--- a/src/app/models/datasets/nisar.ts
+++ b/src/app/models/datasets/nisar.ts
@@ -187,9 +187,9 @@ export const L1L2BrowseCollectionMapping = {
 // Products processed with CRID 5023 or later are provisional calibrated data;
 // earlier CRIDs are pre-calibration ("uncalibrated") products.
 export const calibratedCrid = 5023;
-export const knownIssuesUrl =
-  'https://nisar-docs.asf.alaska.edu/product-known-issues/';
+export const provisionalIssuesUrl =
+  'https://nisar-docs.asf.alaska.edu/provisional-known-issues/';
 // Update once the provisional known issues page is published alongside the
 // July data release; the pre-calibration page currently covers both.
-export const preCalibrationKnownIssuesUrl =
+export const betaIssuesUrl =
   'https://nisar-docs.asf.alaska.edu/product-known-issues/';

--- a/src/app/models/datasets/nisar.ts
+++ b/src/app/models/datasets/nisar.ts
@@ -183,3 +183,13 @@ export const L1L2BrowseCollectionMapping = {
   RUNW: { collection: 'NISAR_L2_GUNW', productType: 'GUNW' },
   ROFF: { collection: 'NISAR_L2_GOFF', productType: 'GOFF' },
 };
+
+// Products processed with CRID 5023 or later are provisional calibrated data;
+// earlier CRIDs are pre-calibration ("uncalibrated") products.
+export const calibratedCrid = 5023;
+export const knownIssuesUrl =
+  'https://nisar-docs.asf.alaska.edu/product-known-issues/';
+// Update once the provisional known issues page is published alongside the
+// July data release; the pre-calibration page currently covers both.
+export const preCalibrationKnownIssuesUrl =
+  'https://nisar-docs.asf.alaska.edu/product-known-issues/';

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -837,6 +837,7 @@
   "PROJECT_NAME_PLACEHOLDER": "Project name placeholder",
   "PROJECT_NAME_REQUIRED": "Project name is required",
   "PROJECT_NAME_UNNAMED": "(unnamed)\n",
+  "PROVISIONAL": "Provisional",
   "PROJECT_NAME_UPDATE_ALL_TOOLTIP": "Update project name for all loaded jobs",
   "PROJECT_NAME_UPDATE_FOR_JOBS": "Update project name for {{count}} jobs",
   "PROJECT_RENAME_CANCELLED": "Project rename cancelled",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -842,6 +842,7 @@
   "PROJECT_NAME_PLACEHOLDER": "Marcador de posición del nombre del proyecto",
   "PROJECT_NAME_REQUIRED": "Se requiere el nombre del proyecto",
   "PROJECT_NAME_UNNAMED": "(sin nombre)",
+  "PROVISIONAL": "Provisional",
   "PROJECT_NAME_UPDATE_ALL_TOOLTIP": "Actualizar el nombre del proyecto para todos los trabajos cargados",
   "PROJECT_NAME_UPDATE_FOR_JOBS": " Actualizar nombre del proyecto para {{count}} trabajos ",
   "PROJECT_RENAME_CANCELLED": "El cambio de nombre del proyecto fue cancelado",


### PR DESCRIPTION
Products with CRID 5023 or later show (Provisional); earlier CRIDs keep (Uncalibrated). The label is decided per scene from its CRID and shown in the scene detail; the dataset selector no longer carries a dataset wide label (TOOL-4882).

The provisional known issues link can be updated in one line in nisar.ts once the new page is published alongside the July release.