### PR TITLE
fix: hidden filters footer on mobile

### DIFF
--- a/src/app/components/filters-dropdown/filters-dropdown.component.scss
+++ b/src/app/components/filters-dropdown/filters-dropdown.component.scss
@@ -36,7 +36,7 @@
 
   z-index: 1020;
   display: flex;
-  height: -webkit-fill-available;
+  height: 100%;
   overflow: hidden;
   flex-direction: column;
   flex-wrap: nowrap;
@@ -78,12 +78,12 @@
   }
 
   .filters-list {
+    flex-shrink: 1;
     flex-grow: 1;
     overflow: auto;
     min-height: 4em;
     max-height: calc(100vh - 170px);
     padding: 10px;
-
   }
 
   .filters-list-mobile {

--- a/src/app/components/filters-dropdown/filters-dropdown.component.scss
+++ b/src/app/components/filters-dropdown/filters-dropdown.component.scss
@@ -33,6 +33,7 @@
   @include themify($themes) {
     background-color: themed('background-white');
   }
+
   z-index: 1020;
   display: flex;
   height: -webkit-fill-available;
@@ -52,11 +53,13 @@
     align-items: center;
     position: sticky;
     top: 0;
+
     @include themify($themes) {
       background-color: themed('primary-light');
       border-bottom: 1px solid themed('primary-dark');
 
     }
+
     font-size: 24px;
     padding: 15px;
     z-index: 1020;
@@ -94,12 +97,14 @@
     justify-content: flex-end;
     position: sticky;
     bottom: 0;
+
     @include themify($themes) {
       background-color: themed('primary-light');
       border-top: 1px solid themed('primary-dark');
 
     }
-    z-index: 1020;
+
+    z-index: 10200;
     padding: 10px;
     min-height: 30px;
 
@@ -125,6 +130,7 @@ h3 {
   @include themify($themes) {
     color: themed('primary')
   }
+
   padding-left: 5px;
   flex-shrink: 0;
   margin-top: 6px;


### PR DESCRIPTION
## Summary
Filters footer is hidden on mobile.

## Tests & Build
- [ ] `npm run lint` passes
- [ ] `npm test` passes (or N/A)
- [ ] `npm run build` succeeds
