### PR TITLE
fix(nisar): show the lat lon browse image in the scene file list

### DIFF
--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -630,8 +630,11 @@ export class ProductService {
         }
       }
       if (productTypeDisplay === 'Browse Image PNG') {
-        if (p === '/assets/no-browse.png') {
+        if (p === '/assets/no-browse.png' || p.endsWith('_thumbnail.png')) {
           continue;
+        }
+        if (p.includes('_LATLON')) {
+          productTypeDisplay = 'Lat/Lon Browse Image PNG';
         }
       }
       const polarizationMatch = /.*_([AB])_([VH]{4}|[VH]{2})\.(png|kml)/;


### PR DESCRIPTION
## Summary
The lat/lon browse shared its display name with the native one, so only one rendered. It now has its own name and thumbnails are skipped.
