### PR TITLE
fix(scenes-list-header): bring back add by file type for NISAR

### DIFF
--- a/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
+++ b/src/app/components/results-menu/scenes-list-header/scenes-list-header.component.html
@@ -438,6 +438,7 @@
               @if (
                 searchType === SearchTypes.DATASET &&
                 (currentDatasetID === 'OPERA-S1' ||
+                  currentDatasetID === 'NISAR' ||
                   currentDatasetID === 'SEASAT')
               ) {
                 <button
@@ -447,7 +448,11 @@
                     productData: (productCountByType$ | async),
                   }"
                 >
-                  {{ 'ADD_BY_PRODUCT_TYPE' | translate }}
+                  {{
+                    currentDatasetID === 'NISAR'
+                      ? ('ADD_BY_FILE_TYPE' | translate)
+                      : ('ADD_BY_PRODUCT_TYPE' | translate)
+                  }}
                 </button>
               }
               @if (


### PR DESCRIPTION
## Summary
Restores the add by file type option for NISAR in the queue menu, now alongside add by group. Verified the other search type menus were untouched by the grouping change, this restores the exact previous behavior.