### PR TITLE
Shared Components Signal Pass

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,11 @@ module.exports = tseslint.config(
       ...angular.configs.tsRecommended,
     ],
     processor: angular.processInlineTemplates,
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+      },
+    },
     rules: {
       '@angular-eslint/component-selector': [
         'error',
@@ -40,6 +45,7 @@ module.exports = tseslint.config(
       'no-useless-escape': 'off',
       '@angular-eslint/no-output-on-prefix': 'off',
       '@angular-eslint/no-output-native': 'off',
+      '@angular-eslint/no-uncalled-signals': 'error',
     },
   },
   {

--- a/src/app/components/sbas-chart/sbas-chart.component.ts
+++ b/src/app/components/sbas-chart/sbas-chart.component.ts
@@ -528,8 +528,8 @@ export class SBASChartComponent implements OnInit, OnDestroy {
     const root = this.chart;
     const bounds = root.node().getBBox();
     const parent = root.node().parentElement;
-    const fullWidth = parent.clientWidth || parent.clientWidth,
-      fullHeight = parent.clientHeight || parent.clientHeight;
+    const fullWidth = parent.clientWidth,
+      fullHeight = parent.clientHeight;
     const width = bounds.width,
       height = bounds.height;
     const midX = bounds.x + width / 2,

--- a/src/app/components/shared/aoi-options/aoi-options.component.ts
+++ b/src/app/components/shared/aoi-options/aoi-options.component.ts
@@ -77,10 +77,9 @@ export class AoiOptionsComponent implements OnInit, OnDestroy {
   public drawMode$ = this.store$.select(mapStore.getMapDrawMode);
   public interactionMode$ = this.store$.select(mapStore.getMapInteractionMode);
 
-  public searchType$ = this.store$.select(getSearchType);
-  public searchtype: SearchType;
-  public isResultsMenuOpen: boolean;
-  public isFiltersMenuOpen: boolean;
+  public searchtype = this.store$.selectSignal(getSearchType);
+  public isResultsMenuOpen = this.store$.selectSignal(getIsResultsMenuOpen);
+  public isFiltersMenuOpen = this.store$.selectSignal(getIsFiltersMenuOpen);
 
   public breakpoint: Breakpoints;
   public breakpoints = Breakpoints;
@@ -110,24 +109,6 @@ export class AoiOptionsComponent implements OnInit, OnDestroy {
       ),
     );
 
-    this.subs.add(
-      this.searchType$.subscribe(
-        (searchtype) => (this.searchtype = searchtype),
-      ),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(getIsFiltersMenuOpen)
-        .subscribe((isOpen) => (this.isFiltersMenuOpen = isOpen)),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(getIsResultsMenuOpen)
-        .subscribe((isOpen) => (this.isResultsMenuOpen = isOpen)),
-    );
-
     this.handleAOIErrors();
   }
 
@@ -141,15 +122,15 @@ export class AoiOptionsComponent implements OnInit, OnDestroy {
 
     if (
       !didLoad ||
-      (this.searchtype === SearchType.DISPLACEMENT &&
+      (this.searchtype() === SearchType.DISPLACEMENT &&
         !polygon.toLowerCase().includes('point'))
     ) {
       this.aoiErrors$.next();
     } else {
       if (
-        this.searchtype === SearchType.DATASET &&
-        this.isResultsMenuOpen &&
-        !this.isFiltersMenuOpen
+        this.searchtype() === SearchType.DATASET &&
+        this.isResultsMenuOpen() &&
+        !this.isFiltersMenuOpen()
       ) {
         this.store$.dispatch(new SetSearchOutOfDate(true));
       }
@@ -160,15 +141,15 @@ export class AoiOptionsComponent implements OnInit, OnDestroy {
     this.store$.dispatch(new SetGeocode(event.geocode));
     if (
       !didLoad ||
-      (this.searchtype === SearchType.DISPLACEMENT &&
+      (this.searchtype() === SearchType.DISPLACEMENT &&
         !event.wkt.toLowerCase().includes('point'))
     ) {
       this.aoiErrors$.next();
     } else {
       if (
-        this.searchtype === SearchType.DATASET &&
-        this.isResultsMenuOpen &&
-        !this.isFiltersMenuOpen
+        this.searchtype() === SearchType.DATASET &&
+        this.isResultsMenuOpen() &&
+        !this.isFiltersMenuOpen()
       ) {
         this.store$.dispatch(new SetSearchOutOfDate(true));
       }

--- a/src/app/components/shared/aoi-options/draw-selector/draw-selector.component.html
+++ b/src/app/components/shared/aoi-options/draw-selector/draw-selector.component.html
@@ -1,4 +1,4 @@
-@if (searchType !== searchTypes.DISPLACEMENT) {
+@if (searchType() !== searchTypes.DISPLACEMENT) {
   <button
     mat-stroked-button
     class="shape-select-button"
@@ -6,13 +6,13 @@
     [attr.aria-label]="'MAP_PROJECTION_VIEW' | translate"
   >
     <div class="shape-select-icon equatorial">
-      @if (drawMode === types.POINT) {
+      @if (drawMode() === types.POINT) {
         <mat-icon class="draw-icon">place</mat-icon>
       }
-      @if (drawMode === types.LINESTRING) {
+      @if (drawMode() === types.LINESTRING) {
         <mat-icon class="draw-icon">timeline</mat-icon>
       }
-      @if (drawMode === types.POLYGON) {
+      @if (drawMode() === types.POLYGON) {
         <svg class="draw-svg-icon" viewBox="0 0 24 24">
           <path
             class="draw-svg"
@@ -20,10 +20,10 @@
           />
         </svg>
       }
-      @if (drawMode === types.BOX) {
+      @if (drawMode() === types.BOX) {
         <mat-icon class="draw-icon">format_shapes</mat-icon>
       }
-      @if (drawMode === types.CIRCLE) {
+      @if (drawMode() === types.CIRCLE) {
         <mat-icon class="draw-icon">radio_button_unchecked</mat-icon>
       }
     </div>
@@ -43,9 +43,9 @@
         >
           <div class="button-text">
             <mat-icon class="material-icons-outlined menu-draw-icon">
-              {{ drawMode | aoiIcon }}
+              {{ drawMode() | aoiIcon }}
             </mat-icon>
-            {{ drawMode.toUpperCase() | translate }}
+            {{ drawMode().toUpperCase() | translate }}
             <span class="mat-select-arrow"></span>
           </div>
         </button>
@@ -56,7 +56,7 @@
           <mat-slide-toggle
             class="draw-toggle"
             (click)="toggleDrawMode()"
-            [checked]="isDrawing"
+            [checked]="isDrawing()"
             [disabled]="isDisabled"
           >
             {{ 'DRAW' | translate | titlecase }}
@@ -80,7 +80,7 @@
     {{ 'PLACE_A_POINT' | translate }}
   </button>
 
-  @if (searchType !== searchTypes.DISPLACEMENT) {
+  @if (searchType() !== searchTypes.DISPLACEMENT) {
     <button
       mat-menu-item
       (click)="onLineStringSelected()"
@@ -94,7 +94,7 @@
     </button>
   }
 
-  @if (searchType !== searchTypes.DISPLACEMENT) {
+  @if (searchType() !== searchTypes.DISPLACEMENT) {
     <button
       mat-menu-item
       (click)="onPolygonSelected()"
@@ -108,7 +108,7 @@
     </button>
   }
 
-  @if (searchType !== searchTypes.DISPLACEMENT) {
+  @if (searchType() !== searchTypes.DISPLACEMENT) {
     <button
       mat-menu-item
       (click)="onBoxSelected()"
@@ -122,7 +122,7 @@
     </button>
   }
 
-  @if (searchType !== searchTypes.DISPLACEMENT) {
+  @if (searchType() !== searchTypes.DISPLACEMENT) {
     <button
       mat-menu-item
       (click)="onCircleSelected()"
@@ -137,7 +137,8 @@
   }
 
   @if (
-    breakpoint !== breakpoints.MOBILE && searchType !== searchTypes.DISPLACEMENT
+    breakpoint !== breakpoints.MOBILE &&
+    searchType() !== searchTypes.DISPLACEMENT
   ) {
     <button
       mat-menu-item

--- a/src/app/components/shared/aoi-options/draw-selector/draw-selector.component.ts
+++ b/src/app/components/shared/aoi-options/draw-selector/draw-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject, computed } from '@angular/core';
 import { SubSink } from 'subsink';
 
 import { Store } from '@ngrx/store';
@@ -43,47 +43,32 @@ export class DrawSelectorComponent implements OnInit, OnDestroy {
   private store$ = inject<Store<AppState>>(Store);
   private screenSize = inject(ScreenSizeService);
 
-  public drawMode: MapDrawModeType;
+  public drawMode = this.store$.selectSignal(mapStore.getMapDrawMode);
   public types = MapDrawModeType;
   private subs = new SubSink();
 
   public breakpoint: Breakpoints;
-  public searchType: SearchType;
+  public searchType = this.store$.selectSignal(searchStore.getSearchType);
   public searchTypes = SearchType;
   public breakpoints = Breakpoints;
 
+  public interactionMode = this.store$.selectSignal(
+    mapStore.getMapInteractionMode,
+  );
   public interaction: MapInteractionModeType;
   public interactionTypes = MapInteractionModeType;
 
-  public isDrawing = true;
+  public isDrawing = computed(() => {
+    return this.interactionMode() === MapInteractionModeType.DRAW;
+  });
   isDisabled = false;
   color: ThemePalette = 'accent';
 
   ngOnInit() {
     this.subs.add(
-      this.store$
-        .select(mapStore.getMapInteractionMode)
-        .subscribe(
-          (mode) => (this.isDrawing = mode === MapInteractionModeType.DRAW),
-        ),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(mapStore.getMapDrawMode)
-        .subscribe((drawMode) => (this.drawMode = drawMode)),
-    );
-
-    this.subs.add(
       this.screenSize.breakpoint$.subscribe(
         (breakpoint) => (this.breakpoint = breakpoint),
       ),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(searchStore.getSearchType)
-        .subscribe((searchType) => (this.searchType = searchType)),
     );
   }
 
@@ -96,7 +81,7 @@ export class DrawSelectorComponent implements OnInit, OnDestroy {
 
   public toggleDrawMode() {
     let newMode = MapInteractionModeType.DRAW;
-    if (this.isDrawing) {
+    if (this.isDrawing()) {
       newMode = MapInteractionModeType.NONE;
     }
     this.onNewInteractionMode(newMode);

--- a/src/app/components/shared/aoi-options/interaction-selector/interaction-selector.component.html
+++ b/src/app/components/shared/aoi-options/interaction-selector/interaction-selector.component.html
@@ -1,5 +1,5 @@
 <mat-button-toggle-group
-  [value]="interaction"
+  [value]="interaction()"
   class="interaction-toggle-group"
   name="viewSelect"
   [attr.aria-label]="'FONT_STYLE' | translate"
@@ -12,7 +12,7 @@
     [value]="types.EDIT"
     class="control-mat-button-toggle"
     [matTooltip]="
-      interaction === types.EDIT
+      interaction() === types.EDIT
         ? ('STOP_EDITING' | translate)
         : ('EDIT_CURRENT_AREA_OF_INTEREST' | translate)
     "
@@ -25,7 +25,7 @@
     [value]="types.DRAW"
     class="control-mat-button-toggle"
     [matTooltip]="
-      interaction === types.DRAW
+      interaction() === types.DRAW
         ? ('STOP_DRAWING' | translate)
         : ('DRAW_NEW_AREA_OF_INTEREST' | translate)
     "

--- a/src/app/components/shared/aoi-options/interaction-selector/interaction-selector.component.ts
+++ b/src/app/components/shared/aoi-options/interaction-selector/interaction-selector.component.ts
@@ -1,19 +1,17 @@
-import { Component, OnInit, ViewChild, OnDestroy, inject } from '@angular/core';
+import { Component, ViewChild, inject } from '@angular/core';
 import {
   MatButtonToggle,
   MatButtonToggleGroup,
 } from '@angular/material/button-toggle';
-import { SubSink } from 'subsink';
 
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
 import * as mapStore from '@store/map';
 import * as uiStore from '@store/ui';
 
-import { MapInteractionModeType, SearchType } from '@models';
+import { MapInteractionModeType } from '@models';
 import * as services from '@services';
 import * as models from '@models';
-import * as searchStore from '@store/search';
 import { DrawSelectorComponent } from '../draw-selector/draw-selector.component';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatIcon } from '@angular/material/icon';
@@ -37,36 +35,17 @@ import { TranslateModule } from '@ngx-translate/core';
     TranslateModule,
   ],
 })
-export class InteractionSelectorComponent implements OnInit, OnDestroy {
+export class InteractionSelectorComponent {
   private store$ = inject<Store<AppState>>(Store);
   private mapService = inject(services.MapService);
   private screenSize = inject(services.ScreenSizeService);
 
   @ViewChild('clearButton') clearButton: MatButtonToggle;
-  public interaction: MapInteractionModeType;
+  public interaction = this.store$.selectSignal(mapStore.getMapInteractionMode);
   public types = MapInteractionModeType;
-
-  public searchType: SearchType;
-  public searchTypes = SearchType;
 
   public breakpoints = models.Breakpoints;
   public breakpoint$ = this.screenSize.breakpoint$;
-
-  private subs = new SubSink();
-
-  ngOnInit() {
-    this.subs.add(
-      this.store$
-        .select(mapStore.getMapInteractionMode)
-        .subscribe((interaction) => (this.interaction = interaction)),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(searchStore.getSearchType)
-        .subscribe((searchType) => (this.searchType = searchType)),
-    );
-  }
 
   public onNewInteractionMode(mode: MapInteractionModeType): void {
     this.store$.dispatch(new mapStore.SetMapInteractionMode(mode));
@@ -74,14 +53,14 @@ export class InteractionSelectorComponent implements OnInit, OnDestroy {
 
   public onDrawSelected = () =>
     this.onNewInteractionMode(
-      this.interaction === MapInteractionModeType.DRAW
+      this.interaction() === MapInteractionModeType.DRAW
         ? MapInteractionModeType.NONE
         : MapInteractionModeType.DRAW,
     );
 
   public onEditSelected = () =>
     this.onNewInteractionMode(
-      this.interaction === MapInteractionModeType.EDIT
+      this.interaction() === MapInteractionModeType.EDIT
         ? MapInteractionModeType.NONE
         : MapInteractionModeType.EDIT,
     );
@@ -99,8 +78,4 @@ export class InteractionSelectorComponent implements OnInit, OnDestroy {
       new mapStore.SetMapInteractionMode(MapInteractionModeType.DRAW),
     );
   };
-
-  ngOnDestroy() {
-    this.subs.unsubscribe();
-  }
 }

--- a/src/app/components/shared/cancel-filter-changes/cancel-filter-changes.component.ts
+++ b/src/app/components/shared/cancel-filter-changes/cancel-filter-changes.component.ts
@@ -1,11 +1,10 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { SearchType } from '@models';
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
 import * as filtersStore from '@store/filters';
 import * as searchStore from '@store/search';
 import * as uiStore from '@store/ui';
-import { SubSink } from 'subsink';
 import { MatButton } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
 @Component({
@@ -14,27 +13,13 @@ import { TranslateModule } from '@ngx-translate/core';
   styleUrls: ['./cancel-filter-changes.component.scss'],
   imports: [MatButton, TranslateModule],
 })
-export class CancelFilterChangesComponent implements OnInit, OnDestroy {
+export class CancelFilterChangesComponent {
   private store$ = inject<Store<AppState>>(Store);
 
-  private searchType$ = this.store$.select(searchStore.getSearchType);
-  private searchType: SearchType;
-  private subs = new SubSink();
-
-  ngOnInit(): void {
-    this.subs.add(
-      this.searchType$.subscribe(
-        (currentSearchType) => (this.searchType = currentSearchType),
-      ),
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subs.unsubscribe();
-  }
+  private searchType = this.store$.selectSignal(searchStore.getSearchType);
 
   public onCancelFiltersChange(): void {
-    if (this.searchType === SearchType.LIST) {
+    if (this.searchType() === SearchType.LIST) {
       this.store$.dispatch(new filtersStore.ClearListFilters());
     }
 

--- a/src/app/components/shared/chart-modal/chart-modal.component.ts
+++ b/src/app/components/shared/chart-modal/chart-modal.component.ts
@@ -1,20 +1,8 @@
-import {
-  Component,
-  OnDestroy,
-  OnInit,
-  Output,
-  EventEmitter,
-  inject,
-} from '@angular/core';
+import { Component, Output, EventEmitter, inject } from '@angular/core';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { TimeseriesChartConfigComponent } from '@components/timeseries-chart/timeseries-chart-config';
-import { AppState } from '@store';
-import { Store } from '@ngrx/store';
-import { SubSink } from 'subsink';
-import { getSearchType } from '@store/search';
-import { SearchType } from '@models';
 
 import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
@@ -33,27 +21,12 @@ import { TranslateModule } from '@ngx-translate/core';
   templateUrl: './chart-modal.component.html',
   styleUrl: './chart-modal.component.scss',
 })
-export class ChartModalComponent implements OnInit, OnDestroy {
+export class ChartModalComponent {
   dialog = inject(MatDialog);
-  private $store = inject<Store<AppState>>(Store);
 
-  private subs = new SubSink();
-  public searchType: SearchType;
-  public SearchTypes = SearchType;
   @Output() public resetReferenceEvent = new EventEmitter();
 
-  ngOnInit(): void {
-    this.subs.add(
-      this.$store
-        .select(getSearchType)
-        .subscribe((searchtype) => (this.searchType = searchtype)),
-    );
-  }
   public onResetReference() {
     this.resetReferenceEvent.emit();
-  }
-
-  ngOnDestroy(): void {
-    this.subs.unsubscribe();
   }
 }

--- a/src/app/components/shared/copy-to-clipboard/copy-to-clipboard.component.ts
+++ b/src/app/components/shared/copy-to-clipboard/copy-to-clipboard.component.ts
@@ -47,7 +47,7 @@ export class CopyToClipboardComponent implements OnDestroy {
   }
   public onCopyIconClicked(e: Event): void {
     this.clipboardService.copyFromContent(this.value());
-    if (this.toast) {
+    if (this.toast()) {
       this.notificationService.info(this.message());
     }
 
@@ -65,7 +65,7 @@ export class CopyToClipboardComponent implements OnDestroy {
 
   public onCopyFromMenu(prompt: string, message: string, value: string) {
     this.clipboardService.copyFromContent(value);
-    if (this.toast) {
+    if (this.toast()) {
       this.notificationService.info(message);
     }
 

--- a/src/app/components/shared/download-file-button/download-file-button.component.ts
+++ b/src/app/components/shared/download-file-button/download-file-button.component.ts
@@ -270,10 +270,7 @@ export class DownloadFileButtonComponent implements OnInit, AfterViewInit {
       .subscribe();
   }
   private isBurstDone(resp, _product): boolean {
-    if (
-      resp.type === HttpEventType.DownloadProgress ||
-      resp.type === HttpEventType.DownloadProgress
-    ) {
+    if (resp.type === HttpEventType.DownloadProgress) {
       return resp.loaded > 1000;
     }
     return false;

--- a/src/app/components/shared/hyp3-job-status-badge/hyp3-job-status-badge.component.ts
+++ b/src/app/components/shared/hyp3-job-status-badge/hyp3-job-status-badge.component.ts
@@ -41,20 +41,14 @@ export class Hyp3JobStatusBadgeComponent implements OnInit {
   public expiredJobs: models.Hyp3Job[] = [];
   public failedJobs: models.Hyp3Job[] = [];
 
-  private costs: models.Hyp3Costs;
-  private processingOptions: Hyp3ProcessingOptions;
+  private costs = this.store$.selectSignal(hyp3Store.getCosts);
+  private processingOptions = this.store$.selectSignal(
+    hyp3Store.getProcessingOptions,
+  );
   private validateOnly = false;
   public remaining = 0;
 
   ngOnInit(): void {
-    this.store$
-      .select(hyp3Store.getProcessingOptions)
-      .subscribe((options) => (this.processingOptions = options));
-
-    this.store$
-      .select(hyp3Store.getCosts)
-      .subscribe((costs) => (this.costs = costs));
-
     this.store$.select(hyp3Store.getHyp3User).subscribe((user) => {
       if (user === null) {
         return;
@@ -119,14 +113,14 @@ export class Hyp3JobStatusBadgeComponent implements OnInit {
   }
 
   private openConfirmationDialog(jobType: models.Hyp3JobType, job) {
-    let options: Hyp3ProcessingOptions = this.processingOptions;
+    let options: Hyp3ProcessingOptions = this.processingOptions();
 
     const jobTypeOptions = { ...options[jobType.id] };
 
     for (const [optionName, optionVal] of Object.entries(
       job.processingOptions,
     )) {
-      if (optionName in this.processingOptions[jobType.id]) {
+      if (optionName in this.processingOptions()[jobType.id]) {
         jobTypeOptions[optionName] = optionVal;
       }
     }
@@ -138,7 +132,7 @@ export class Hyp3JobStatusBadgeComponent implements OnInit {
 
     const costPerJob = this.hyp3.calculateCredits(
       options[jobType.id],
-      this.costs[jobType.id],
+      this.costs()[jobType.id],
     );
 
     const jobTypesWithQueued = [

--- a/src/app/components/shared/max-results-selector/max-results-selector.component.html
+++ b/src/app/components/shared/max-results-selector/max-results-selector.component.html
@@ -8,13 +8,13 @@
   @if (isDataset) {
     <span>
       <span>
-        {{ maxResults | formatNumber }}
+        {{ maxResults() | formatNumber }}
         <mat-icon class="faint-text clickable"> arrow_drop_down</mat-icon>
       </span>
       {{ 'OF' | translate }}
     </span>
   }
-  @if (!isMaxResultsLoading) {
+  @if (!isMaxResultsLoading()) {
     <span>
       {{ totalResultsCount !== -1 ? (totalResultsCount | formatNumber) : '0' }}
     </span>

--- a/src/app/components/shared/max-results-selector/max-results-selector.component.ts
+++ b/src/app/components/shared/max-results-selector/max-results-selector.component.ts
@@ -51,9 +51,15 @@ export class MaxResultsSelectorComponent implements OnInit, OnDestroy {
   private pairService = inject(PairService);
   private sceneService = inject(ScenesService);
 
-  public maxResults: number;
-  public isMaxResultsLoading: boolean;
-  public areResultsLoaded = false;
+  public maxResults = this.store$.selectSignal(
+    filtersStore.getMaxSearchResults,
+  );
+  public isMaxResultsLoading = this.store$.selectSignal(
+    searchStore.getIsMaxResultsLoading,
+  );
+  public areResultsLoaded = this.store$.selectSignal(
+    scenesStore.getAreResultsLoaded,
+  );
 
   public searchType: models.SearchType;
   public searchTypes = models.SearchType;
@@ -66,22 +72,6 @@ export class MaxResultsSelectorComponent implements OnInit, OnDestroy {
   private subs = new SubSink();
 
   ngOnInit() {
-    this.subs.add(
-      this.store$
-        .select(filtersStore.getMaxSearchResults)
-        .subscribe((maxResults) => (this.maxResults = maxResults)),
-    );
-    this.subs.add(
-      this.store$
-        .select(scenesStore.getAreResultsLoaded)
-        .subscribe((areLoaded) => (this.areResultsLoaded = areLoaded)),
-    );
-    this.subs.add(
-      this.store$
-        .select(searchStore.getIsMaxResultsLoading)
-        .subscribe((isLoading) => (this.isMaxResultsLoading = isLoading)),
-    );
-
     this.subs.add(
       combineLatest([
         this.store$.select(searchStore.getSearchType),
@@ -119,7 +109,7 @@ export class MaxResultsSelectorComponent implements OnInit, OnDestroy {
   public onNewMaxResults(maxResults: number): void {
     this.store$.dispatch(new filtersStore.SetMaxResults(maxResults));
 
-    if (this.areResultsLoaded) {
+    if (this.areResultsLoaded()) {
       this.store$.dispatch(new searchStore.MakeSearch());
     }
   }

--- a/src/app/components/shared/on-demand-add-menu/closest-pair/closest-pair.component.html
+++ b/src/app/components/shared/on-demand-add-menu/closest-pair/closest-pair.component.html
@@ -3,16 +3,16 @@
   <input
     matInput
     type="number"
-    [max]="scenes.length - 1"
+    [max]="scenes().length - 1"
     [min]="1"
     [placeholder]="points.toString()"
     (input)="updatePairCount($event)"
     (click)="$event.stopPropagation()"
   />
 </mat-form-field>
-<button (click)="queueClosestPair(InSAR)" [disabled]="" mat-menu-item>
+<button (click)="queueClosestPair(InSAR)" [disabled]="false" mat-menu-item>
   {{ 'IN_SAR_PAIR' | translate }}
 </button>
-<button (click)="queueClosestPair(AutoRift)" [disabled]="" mat-menu-item>
+<button (click)="queueClosestPair(AutoRift)" [disabled]="false" mat-menu-item>
   {{ 'AUTO_RIFT_PAIR' | translate }}
 </button>

--- a/src/app/components/shared/on-demand-add-menu/closest-pair/closest-pair.component.ts
+++ b/src/app/components/shared/on-demand-add-menu/closest-pair/closest-pair.component.ts
@@ -21,11 +21,11 @@ export class ClosestPairComponent implements OnInit {
   private store$ = inject<Store<AppState>>(Store);
   private pairService = inject(PairService);
 
-  public scenes: CMRProduct[] = [];
+  public scenes = this.store$.selectSignal(getScenes);
   public points = 1;
   private referenceScene: CMRProduct;
   private referenceSceneIdx: number;
-  private temporalRange;
+  private temporalRange = this.store$.selectSignal(getTemporalRange);
 
   public InSAR = models.hyp3JobTypes.INSAR_GAMMA;
   public AutoRift = models.hyp3JobTypes.AUTORIFT;
@@ -34,30 +34,20 @@ export class ClosestPairComponent implements OnInit {
 
   ngOnInit(): void {
     this.subs.add(
-      this.store$
-        .select(getScenes)
-        .subscribe((scenes) => (this.scenes = scenes)),
-    );
-    this.subs.add(
       this.store$.select(getMasterName).subscribe((refSceneName) => {
-        this.referenceSceneIdx = this.scenes.findIndex(
+        this.referenceSceneIdx = this.scenes().findIndex(
           (scene) => scene.name === refSceneName,
         );
-        this.referenceScene = this.scenes[this.referenceSceneIdx];
+        this.referenceScene = this.scenes()[this.referenceSceneIdx];
       }),
-    );
-    this.subs.add(
-      this.store$
-        .select(getTemporalRange)
-        .subscribe((range) => (this.temporalRange = range)),
     );
   }
 
   public queueClosestPair(job_type: models.Hyp3JobType): void {
     const closestProduct = this.pairService.findNearestneighbour(
       this.referenceScene,
-      this.scenes.filter((scene) => this.referenceScene.id !== scene.id),
-      this.temporalRange,
+      this.scenes().filter((scene) => this.referenceScene.id !== scene.id),
+      this.temporalRange(),
       this.points,
     );
 
@@ -83,6 +73,6 @@ export class ClosestPairComponent implements OnInit {
 
   public updatePairCount(event: Event) {
     const val = (event.target as HTMLInputElement).valueAsNumber;
-    this.points = Math.min(val, this.scenes.length - 2);
+    this.points = Math.min(val, this.scenes().length - 2);
   }
 }

--- a/src/app/components/shared/on-demand-add-menu/on-demand-add-menu.component.html
+++ b/src/app/components/shared/on-demand-add-menu/on-demand-add-menu.component.html
@@ -32,9 +32,13 @@
       @if (prodType.products.length !== 0) {
         <button
           (click)="
-            queueAllOnDemand(prodType.products, byJobType.jobType, isFrameBased)
+            queueAllOnDemand(
+              prodType.products,
+              byJobType.jobType,
+              isFrameBased()
+            )
           "
-          [disabled]=""
+          [disabled]="false"
           mat-menu-item
         >
           {{ 'ADD' | translate }}

--- a/src/app/components/shared/on-demand-add-menu/on-demand-add-menu.component.ts
+++ b/src/app/components/shared/on-demand-add-menu/on-demand-add-menu.component.ts
@@ -8,14 +8,12 @@ import {
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
 import * as queueStore from '@store/queue';
-import * as userStore from '@store/user';
 import * as hyp3Store from '@store/hyp3';
 import * as uiStore from '@store/ui';
 
 import * as models from '@models';
 import { SubSink } from 'subsink';
 import { getMasterName, getScenes } from '@store/scenes';
-import { getSearchType } from '@store/search';
 import { CMRProduct, Hyp3ableByProductType, SearchType } from '@models';
 import { withLatestFrom } from 'rxjs/operators';
 import { EnvironmentService, Hyp3ApiService } from '@services';
@@ -58,54 +56,25 @@ export class OnDemandAddMenuComponent implements OnInit {
 
   @ViewChild('addMenu', { static: true }) addMenu: MatMenu;
 
-  public isLoggedIn = false;
-
   public referenceScene: CMRProduct;
 
   private scenes: CMRProduct[];
-  public costs;
-  public options;
+  public costs = this.store$.selectSignal(hyp3Store.getCosts);
+  public options = this.store$.selectSignal(hyp3Store.getProcessingOptions);
 
-  public searchType: models.SearchType;
   public searchTypes = models.SearchType;
   public InSAR = models.hyp3JobTypes.INSAR_GAMMA;
   public AutoRift = models.hyp3JobTypes.AUTORIFT;
 
-  public isFrameBased = false;
+  public isFrameBased = this.store$.selectSignal(
+    getShouldUseFramesForReference,
+  );
   private referenceID: string;
   public userStatus;
 
   private subs = new SubSink();
 
   ngOnInit(): void {
-    this.subs.add(
-      this.store$
-        .select(getShouldUseFramesForReference)
-        .subscribe((isFrameBased) => (this.isFrameBased = isFrameBased)),
-    );
-    this.subs.add(
-      this.store$
-        .select(getSearchType)
-        .subscribe((searchtype) => (this.searchType = searchtype)),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(userStore.getIsUserLoggedIn)
-        .subscribe((isLoggedIn) => (this.isLoggedIn = isLoggedIn)),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(hyp3Store.getCosts)
-        .subscribe((costs) => (this.costs = costs)),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(hyp3Store.getProcessingOptions)
-        .subscribe((options) => (this.options = options)),
-    );
     this.subs.add(
       this.store$.select(hyp3Store.getHyp3User).subscribe((profile) => {
         this.userStatus = profile?.application_status;
@@ -211,8 +180,8 @@ export class OnDemandAddMenuComponent implements OnInit {
   public calculateCost(jobTypeId: string, numberOfJobs: number): number {
     return (
       this.hyp3.calculateCredits(
-        this.options[jobTypeId],
-        this.costs[jobTypeId],
+        this.options()[jobTypeId],
+        this.costs()[jobTypeId],
       ) * numberOfJobs
     );
   }

--- a/src/app/components/shared/search-button/search-button.component.html
+++ b/src/app/components/shared/search-button/search-button.component.html
@@ -1,6 +1,6 @@
 @if (breakpoint$ | async; as breakpoint) {
   <span>
-    @if (searchType !== searchTypes.DISPLACEMENT) {
+    @if (searchType() !== searchTypes.DISPLACEMENT) {
       <mat-button-toggle-group
         [hideSingleSelectionIndicator]="true"
         [hideMultipleSelectionIndicator]="true"
@@ -15,7 +15,7 @@
             [disabled]="
               (!(canSearch$ | async) && !(isMaxResultsLoading$ | async)) ||
               ((isFrameSelectionEnabled$ | async) &&
-                searchType === searchTypes.DATASET &&
+                searchType() === searchTypes.DATASET &&
                 !isFiltersOpen)
             "
             mat-flat-button
@@ -41,11 +41,11 @@
         </mat-button-toggle>
       </mat-button-toggle-group>
     }
-    @if (searchType === searchTypes.DISPLACEMENT) {
+    @if (searchType() === searchTypes.DISPLACEMENT) {
       <span class="displacement-header-menu">
         <button
           [matMenuTriggerFor]="searchActionDropdown"
-          matTooltip="{{ 'SHARE_SAVE_INFORMATION' | translate }}"
+          [matTooltip]="'SHARE_SAVE_INFORMATION' | translate"
           class="spacing nav-icon-buttons"
           color="basic"
           mat-button
@@ -58,41 +58,41 @@
       </span>
     }
     <mat-menu #searchActionDropdown="matMenu">
-      @if (searchType !== searchTypes.DISPLACEMENT) {
+      @if (searchType() !== searchTypes.DISPLACEMENT) {
         <button mat-menu-item (click)="onClearSearch()">
           {{ 'CLEAR_SEARCH' | translate }}
         </button>
         <mat-divider></mat-divider>
       }
       <span
-        [matTooltipDisabled]="isLoggedIn"
-        matTooltip="{{ 'SIGN_IN_TO_SEE_YOUR_SAVED_SEARCHES' | translate }}"
+        [matTooltipDisabled]="isLoggedIn()"
+        [matTooltip]="'SIGN_IN_TO_SEE_YOUR_SAVED_SEARCHES' | translate"
         matTooltipPosition="after"
       >
         <button mat-menu-item [matMenuTriggerFor]="savedSearchesMenu">
           {{ 'SAVED_SEARCHES' | translate }}
         </button>
       </span>
-      @if (searchType !== searchTypes.DISPLACEMENT) {
+      @if (searchType() !== searchTypes.DISPLACEMENT) {
         <span
           [matTooltipDisabled]="
-            isLoggedIn &&
-            searchType !== searchTypes.LIST &&
-            searchType !== searchTypes.CUSTOM_PRODUCTS
+            isLoggedIn() &&
+            searchType() !== searchTypes.LIST &&
+            searchType() !== searchTypes.CUSTOM_PRODUCTS
           "
-          matTooltip="{{
-            isLoggedIn &&
-            (searchType === searchTypes.LIST ||
-              searchType === searchTypes.CUSTOM_PRODUCTS)
+          [matTooltip]="
+            isLoggedIn() &&
+            (searchType() === searchTypes.LIST ||
+              searchType() === searchTypes.CUSTOM_PRODUCTS)
               ? ('SAVED_FILTERS_ARE_NOT_AVAILABLE_FOR_SEARCH_TYPE' | translate)
               : ('SIGN_IN_TO_SEE_YOUR_SAVED_FILTERS' | translate)
-          }}"
+          "
           matTooltipPosition="after"
         >
           <button
             [disabled]="
-              searchType === searchTypes.LIST ||
-              searchType === searchTypes.CUSTOM_PRODUCTS
+              searchType() === searchTypes.LIST ||
+              searchType() === searchTypes.CUSTOM_PRODUCTS
             "
             mat-menu-item
             [matMenuTriggerFor]="savedFiltersMenu"
@@ -105,7 +105,7 @@
       <button mat-menu-item [matMenuTriggerFor]="shareSearchMenu">
         {{ 'SHARE_SEARCH' | translate }}
       </button>
-      @if (searchType !== searchTypes.DISPLACEMENT) {
+      @if (searchType() !== searchTypes.DISPLACEMENT) {
         <button mat-menu-item [matMenuTriggerFor]="exportSearchMenu">
           {{ 'EXPORT' | translate }}
         </button>
@@ -119,18 +119,18 @@
     </mat-menu>
     <mat-menu #savedFiltersMenu="matMenu">
       <span
-        matTooltip="{{ 'SIGN_IN_TO_SAVE_YOUR_FILTERS' | translate }}"
-        [matTooltipDisabled]="isLoggedIn"
+        [matTooltip]="'SIGN_IN_TO_SAVE_YOUR_FILTERS' | translate"
+        [matTooltipDisabled]="isLoggedIn()"
         matTooltipPosition="after"
       >
         @if (
-          searchType !== searchTypes.CUSTOM_PRODUCTS &&
-          searchType !== searchTypes.LIST &&
-          searchType !== searchTypes.DISPLACEMENT
+          searchType() !== searchTypes.CUSTOM_PRODUCTS &&
+          searchType() !== searchTypes.LIST &&
+          searchType() !== searchTypes.DISPLACEMENT
         ) {
           <button
             mat-menu-item
-            [disabled]="!isLoggedIn"
+            [disabled]="!isLoggedIn()"
             (click)="saveCurrentFilters()"
           >
             {{ 'SAVE_FILTERS' | translate }}
@@ -138,19 +138,19 @@
         }
       </span>
       <span
-        [matTooltipDisabled]="isLoggedIn"
-        matTooltip="{{ 'SIGN_IN_TO_SEE_YOUR_SAVED_FILTERS' | translate }}"
+        [matTooltipDisabled]="isLoggedIn()"
+        [matTooltip]="'SIGN_IN_TO_SEE_YOUR_SAVED_FILTERS' | translate"
         matTooltipPosition="after"
       >
         @if (
-          searchType !== searchTypes.CUSTOM_PRODUCTS &&
-          searchType !== searchTypes.LIST &&
-          searchType !== searchTypes.DISPLACEMENT
+          searchType() !== searchTypes.CUSTOM_PRODUCTS &&
+          searchType() !== searchTypes.LIST &&
+          searchType() !== searchTypes.DISPLACEMENT
         ) {
           <button
             (click)="onOpenSavedFilters()"
             mat-menu-item
-            [disabled]="!isLoggedIn"
+            [disabled]="!isLoggedIn()"
           >
             {{ 'VIEW_FILTERS' | translate }}
           </button>
@@ -166,7 +166,7 @@
         (click)="onShareWithEmail()"
         href="mailto:?subject=&body=:%20"
         target="_blank"
-        title="{{ 'SHARE_WITH_EMAIL' | translate }}"
+        [title]="'SHARE_WITH_EMAIL' | translate"
         mat-menu-item
         matSuffix
       >
@@ -176,14 +176,14 @@
     </mat-menu>
     <mat-menu #savedSearchesMenu="matMenu">
       <span
-        matTooltip="{{ 'SIGN_IN_TO_SAVE_YOUR_SEARCH' | translate }}"
-        [matTooltipDisabled]="isLoggedIn"
+        [matTooltip]="'SIGN_IN_TO_SAVE_YOUR_SEARCH' | translate"
+        [matTooltipDisabled]="isLoggedIn()"
         matTooltipPosition="after"
       >
-        @if (searchType !== searchTypes.CUSTOM_PRODUCTS) {
+        @if (searchType() !== searchTypes.CUSTOM_PRODUCTS) {
           <button
             mat-menu-item
-            [disabled]="!isLoggedIn"
+            [disabled]="!isLoggedIn()"
             (click)="saveCurrentSearch()"
           >
             {{ 'SAVE_SEARCH' | translate }}
@@ -191,26 +191,26 @@
         }
       </span>
       <span
-        [matTooltipDisabled]="isLoggedIn"
-        matTooltip="{{ 'SIGN_IN_TO_SEE_YOUR_SAVED_SEARCHES' | translate }}"
+        [matTooltipDisabled]="isLoggedIn()"
+        [matTooltip]="'SIGN_IN_TO_SEE_YOUR_SAVED_SEARCHES' | translate"
         matTooltipPosition="after"
       >
         <button
           mat-menu-item
-          [disabled]="!isLoggedIn"
+          [disabled]="!isLoggedIn()"
           (click)="onOpenSavedSearches()"
         >
           {{ 'VIEW_SEARCHES' | translate }}
         </button>
       </span>
       <span
-        [matTooltipDisabled]="isLoggedIn"
-        matTooltip="{{ 'SIGN_IN_TO_SEE_YOUR_SEARCH_HISTORY' | translate }}"
+        [matTooltipDisabled]="isLoggedIn()"
+        [matTooltip]="'SIGN_IN_TO_SEE_YOUR_SEARCH_HISTORY' | translate"
         matTooltipPosition="after"
       >
         <button
           mat-menu-item
-          [disabled]="!isLoggedIn"
+          [disabled]="!isLoggedIn()"
           (click)="onOpenSearchHistory()"
         >
           {{ 'SEARCH_HISTORY' | translate }}...
@@ -225,10 +225,10 @@
         matSuffix
         [disabled]="
           !(
-            searchType === searchTypes.DATASET ||
-            searchType === searchTypes.LIST ||
-            searchType === searchTypes.BASELINE ||
-            searchType === searchTypes.CUSTOM_PRODUCTS
+            searchType() === searchTypes.DATASET ||
+            searchType() === searchTypes.LIST ||
+            searchType() === searchTypes.BASELINE ||
+            searchType() === searchTypes.CUSTOM_PRODUCTS
           )
         "
       >

--- a/src/app/components/shared/search-button/search-button.component.ts
+++ b/src/app/components/shared/search-button/search-button.component.ts
@@ -88,7 +88,7 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
   private exportService = inject(services.ExportService);
   private screenSize = inject(ScreenSizeService);
 
-  public searchType: SearchType;
+  public searchType = this.store$.selectSignal(searchStore.getSearchType);
   public searchTypes = SearchType;
   public canSearch$ = this.store$.select(searchStore.getCanSearch);
   public isMaxResultsLoading$ = this.store$.select(
@@ -106,7 +106,7 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
     searchStore.getareResultsOutOfDate,
   );
 
-  public isLoggedIn = false;
+  public isLoggedIn = this.store$.selectSignal(userStore.getIsUserLoggedIn);
   public searchError$ = new Subject<searchStore.SearchError>();
   public isSearchError = false;
   public isFiltersOpen = false;
@@ -115,27 +115,11 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
 
   private stackReferenceScene: string;
   private latestReferenceScene: string;
-  private resultsMenuOpen = false;
+  private resultsMenuOpen = this.store$.selectSignal(
+    uiStore.getIsResultsMenuOpen,
+  );
 
   ngOnInit() {
-    this.subs.add(
-      this.store$
-        .select(userStore.getIsUserLoggedIn)
-        .subscribe((isLoggedIn) => (this.isLoggedIn = isLoggedIn)),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(searchStore.getSearchType)
-        .subscribe((searchType) => (this.searchType = searchType)),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(uiStore.getIsResultsMenuOpen)
-        .subscribe((isOpen) => (this.resultsMenuOpen = isOpen)),
-    );
-
     this.subs.add(
       this.actions$
         .pipe(
@@ -165,8 +149,8 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
         this.store$.select(uiStore.getIsFiltersMenuOpen),
       ]).subscribe(([latestFilter, isOpen]) => {
         if (
-          (isOpen && this.searchType === this.searchTypes.BASELINE) ||
-          this.searchType === this.searchTypes.SBAS
+          (isOpen && this.searchType() === this.searchTypes.BASELINE) ||
+          this.searchType() === this.searchTypes.SBAS
         ) {
           this.latestReferenceScene = latestFilter;
           if (this.stackReferenceScene == null || '') {
@@ -182,17 +166,17 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
 
   public onDoSearch(): void {
     if (
-      ((this.searchType === this.searchTypes.SBAS ||
-        this.searchType === this.searchTypes.BASELINE) &&
+      ((this.searchType() === this.searchTypes.SBAS ||
+        this.searchType() === this.searchTypes.BASELINE) &&
         this.isFiltersOpen &&
         (this.stackReferenceScene !== this.latestReferenceScene ||
-          !this.resultsMenuOpen)) ||
+          !this.resultsMenuOpen())) ||
       ((this.stackReferenceScene !== this.latestReferenceScene ||
         !this.isFiltersOpen) &&
-        (this.searchType === this.searchTypes.SBAS ||
-          this.searchType === this.searchTypes.BASELINE)) ||
-      (this.searchType !== this.searchTypes.SBAS &&
-        this.searchType !== this.searchTypes.BASELINE)
+        (this.searchType() === this.searchTypes.SBAS ||
+          this.searchType() === this.searchTypes.BASELINE)) ||
+      (this.searchType() !== this.searchTypes.SBAS &&
+        this.searchType() !== this.searchTypes.BASELINE)
     ) {
       this.store$.dispatch(new searchStore.MakeSearch());
 
@@ -212,7 +196,7 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
     this.store$.dispatch(new filtersStore.ClearListFilters());
     this.store$.dispatch(new searchStore.ClearSearch());
 
-    if (this.searchType === SearchType.CUSTOM_PRODUCTS) {
+    if (this.searchType() === SearchType.CUSTOM_PRODUCTS) {
       this.store$.dispatch(new hyp3Store.SetOnDemandUserID(null));
     }
   }
@@ -352,7 +336,7 @@ export class SearchButtonComponent implements OnInit, OnDestroy {
   }
 
   public exportPython(): void {
-    if (this.searchType !== SearchType.CUSTOM_PRODUCTS) {
+    if (this.searchType() !== SearchType.CUSTOM_PRODUCTS) {
       this.exportService.convertSearchAPIQueryToAsfSearch
         .pipe(take(1))
         .subscribe((data) => {

--- a/src/app/components/shared/selectors/date-range/date-range.component.ts
+++ b/src/app/components/shared/selectors/date-range/date-range.component.ts
@@ -6,6 +6,7 @@ import {
   EventEmitter,
   OnDestroy,
   inject,
+  effect,
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { tap, delay, map } from 'rxjs/operators';
@@ -92,16 +93,13 @@ export class DateRangeComponent implements OnInit, OnDestroy {
 
   public breakpoint: models.Breakpoints;
   public breakpoints = models.Breakpoints;
-
+  public currentLanguage = this.store$.selectSignal(uiStore.getCurrentLanguage);
+  constructor() {
+    effect(() => {
+      this.setCalLang(this.currentLanguage());
+    });
+  }
   ngOnInit(): void {
-    this.subs.add(
-      this.store$
-        .select(uiStore.getCurrentLanguage)
-        .subscribe((currentLanguage) => {
-          this.setCalLang(currentLanguage);
-        }),
-    );
-
     this.screenSize.breakpoint$.subscribe(
       (breakpoint) => (this.breakpoint = breakpoint),
     );

--- a/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.html
+++ b/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.html
@@ -13,7 +13,7 @@
             matInput
             placeholder="S1A..."
             (input)="onFilterProductName($event)"
-            [value]="productNameFilter"
+            [value]="productNameFilter()"
             [matAutocomplete]="jobNameSelector"
             [formControl]="myControl"
             [rows]="5"
@@ -37,7 +37,7 @@
         matInput
         placeholder="S1A..."
         (input)="onFilterProductName($event)"
-        [value]="productNameFilter"
+        [value]="productNameFilter()"
         [formControl]="myControl"
         [matAutocomplete]="jobNameSelector"
       />
@@ -89,7 +89,7 @@
             matInput
             placeholder="S1A..."
             (input)="onFilterProductName($event)"
-            [value]="productNameFilter"
+            [value]="productNameFilter()"
             [matAutocomplete]="jobNameSelector"
             [formControl]="myControl"
             [rows]="5"

--- a/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.ts
+++ b/src/app/components/shared/selectors/job-product-name-selector/job-product-name-selector.component.ts
@@ -72,7 +72,9 @@ export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
 
   @Input() headerView: boolean;
 
-  public productNameFilter = '';
+  public productNameFilter = this.store$.selectSignal(
+    filtersStore.getProductNameFilter,
+  );
   private subs = new SubSink();
   public filteredOptions: EventEmitter<string[]> = new EventEmitter<string[]>();
   public unfilteredScenes: string[];
@@ -85,14 +87,6 @@ export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
   public screenWidth: number;
 
   ngOnInit(): void {
-    this.subs.add(
-      this.store$
-        .select(filtersStore.getProductNameFilter)
-        .subscribe(
-          (productNameFilter) => (this.productNameFilter = productNameFilter),
-        ),
-    );
-
     this.subs.add(
       this.screenSize.size$.subscribe(
         (screenSize) => (this.screenWidth = screenSize.width),
@@ -133,8 +127,8 @@ export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
       ])
         .pipe(map(([_, filteredRes]) => filteredRes))
         .subscribe((res) => {
-          if (this.productNameFilter != null) {
-            const temp = this.productNameFilter
+          if (this.productNameFilter() != null) {
+            const temp = this.productNameFilter()
               .replace(/\s+/g, '')
               .endsWith(',')
               ? this.unfilteredScenes.filter((scene) => !res.includes(scene))
@@ -172,12 +166,12 @@ export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
   public autoCompleteEntry(suggestion: string) {
     let output = '';
 
-    if (this.productNameFilter != null) {
-      if (this.productNameFilter.split(',').length > 1) {
-        if (this.productNameFilter.replace(/\s+/g, '').endsWith(',')) {
-          output = this.productNameFilter + suggestion;
+    if (this.productNameFilter() != null) {
+      if (this.productNameFilter().split(',').length > 1) {
+        if (this.productNameFilter().replace(/\s+/g, '').endsWith(',')) {
+          output = this.productNameFilter() + suggestion;
         } else {
-          const fields = this.productNameFilter.split(',');
+          const fields = this.productNameFilter().split(',');
           fields[fields.length - 1] = suggestion;
           output = fields.join(', ');
         }
@@ -189,11 +183,11 @@ export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
   }
 
   public autoSuggestion(suggestion: string) {
-    if (this.productNameFilter == null) {
+    if (this.productNameFilter() == null) {
       return suggestion;
     }
-    if (this.productNameFilter.split(',').length > 1) {
-      const filenames = this.productNameFilter
+    if (this.productNameFilter().split(',').length > 1) {
+      const filenames = this.productNameFilter()
         .replace(/\s+/g, '')
         .toLowerCase();
       if (filenames.endsWith(',')) {
@@ -204,7 +198,7 @@ export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
         return suggestion.includes(lastEntry) ? suggestion : '';
       }
     }
-    return suggestion.includes(this.productNameFilter) ? suggestion : '';
+    return suggestion.includes(this.productNameFilter()) ? suggestion : '';
   }
 
   public autoSuggestionDisplay(suggestion: string) {
@@ -247,10 +241,9 @@ export class JobProductNameSelectorComponent implements OnInit, OnDestroy {
   }
 
   private latestInput(): string {
-    const entries = this.productNameFilter.replace(/\s+/g, '').split(',');
+    const entries = this.productNameFilter().replace(/\s+/g, '').split(',');
     return entries[entries.length - 1].toLowerCase();
   }
-
   public toggleJobFilterOptions() {
     this.isJobFilterOptionsOpen = !this.isJobFilterOptionsOpen;
   }

--- a/src/app/components/shared/selectors/master-scene-selector/master-scene-selector.component.html
+++ b/src/app/components/shared/selectors/master-scene-selector/master-scene-selector.component.html
@@ -1,7 +1,7 @@
 <form>
   <mat-form-field class="w100">
     <mat-label>{{
-      (shouldUseFramesForReference ? 'FRAME' : 'SCENE') | translate
+      (shouldUseFramesForReference() ? 'FRAME' : 'SCENE') | translate
     }}</mat-label>
     <input
       (input)="onMasterSceneChanged($event)"

--- a/src/app/components/shared/selectors/master-scene-selector/master-scene-selector.component.ts
+++ b/src/app/components/shared/selectors/master-scene-selector/master-scene-selector.component.ts
@@ -26,7 +26,9 @@ export class MasterSceneSelectorComponent implements OnInit, OnDestroy {
   public selectedDataset = 'SENTINEL-1 INTERFEROGRAM (BETA)';
   public SearchTypes = SearchType;
   public masterScene: string;
-  public shouldUseFramesForReference = false;
+  public shouldUseFramesForReference = this.store$.selectSignal(
+    filtersStore.getShouldUseFramesForReference,
+  );
   private subs = new SubSink();
 
   ngOnInit(): void {
@@ -34,15 +36,6 @@ export class MasterSceneSelectorComponent implements OnInit, OnDestroy {
       this.store$
         .select(scenesStore.getFilterMaster)
         .subscribe((master) => (this.masterScene = master)),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(filtersStore.getShouldUseFramesForReference)
-        .subscribe(
-          (shouldUseFrames) =>
-            (this.shouldUseFramesForReference = shouldUseFrames),
-        ),
     );
   }
 
@@ -54,7 +47,9 @@ export class MasterSceneSelectorComponent implements OnInit, OnDestroy {
 
   public onFrameModeToggled() {
     this.store$.dispatch(
-      new filtersStore.SetUseFrameForBaseline(this.shouldUseFramesForReference),
+      new filtersStore.SetUseFrameForBaseline(
+        this.shouldUseFramesForReference(),
+      ),
     );
   }
 

--- a/src/app/components/shared/selectors/mission-selector/mission-selector.component.html
+++ b/src/app/components/shared/selectors/mission-selector/mission-selector.component.html
@@ -9,13 +9,13 @@
   </mat-form-field>
 </form>
 
-@if (!!selectedMission) {
+@if (!!selectedMission()) {
   <div class="selected">
     <div class="selected-row">
       <div>
         <span class="v-mid selected-label">
           <b>{{ 'SELECTED' | translate }}</b> <span> • </span>
-          {{ selectedMission }}
+          {{ selectedMission() }}
         </span>
       </div>
       <div>
@@ -24,7 +24,7 @@
           class="clickable v-mid clear-mission-icon"
           mat-list-icon
           matTooltip="{{ 'CLEAR_SELECTED_MISSION' | translate }}"
-          >{{ 'CLEAR' | translate }}</mat-icon
+          >clear</mat-icon
         >
       </div>
     </div>

--- a/src/app/components/shared/selectors/mission-selector/mission-selector.component.ts
+++ b/src/app/components/shared/selectors/mission-selector/mission-selector.component.ts
@@ -61,17 +61,15 @@ export class MissionSelectorComponent implements OnInit, OnDestroy {
   private store$ = inject<Store<AppState>>(Store);
   private fb = inject(UntypedFormBuilder);
 
-  public missionsByDataset$ = this.store$.select(
-    filtersStore.getMissionsByDataset,
-  );
-  public missionDatasets$ = this.missionsByDataset$.pipe(
-    map((missions) => Object.keys(missions)),
-  );
   public dataset$ = this.store$.select(filtersStore.getSelectedDataset);
 
-  public missionsByDataset: Record<string, string[]>;
-  public missionDatasets: string[];
-  public selectedMission: string | null;
+  public missionsByDataset = this.store$.selectSignal(
+    filtersStore.getMissionsByDataset,
+  );
+
+  public selectedMission = this.store$.selectSignal(
+    filtersStore.getSelectedMission,
+  );
 
   public filteredMissions: string[];
   public datasetFilter: string | null = null;
@@ -88,22 +86,9 @@ export class MissionSelectorComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.subs.add(
-      this.missionsByDataset$.subscribe((missions) => {
-        this.missionsByDataset = missions;
+      this.store$.select(filtersStore.getMissionsByDataset).subscribe((_) => {
         this.filteredMissions = this._filterGroup(this.currentFilter);
       }),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(filtersStore.getSelectedMission)
-        .subscribe((selected) => (this.selectedMission = selected)),
-    );
-
-    this.subs.add(
-      this.missionDatasets$.subscribe(
-        (datasets) => (this.missionDatasets = datasets),
-      ),
     );
 
     this.subs.add(
@@ -138,8 +123,8 @@ export class MissionSelectorComponent implements OnInit, OnDestroy {
 
   private _filterGroup(filterValue: string): string[] {
     const missionsUnfiltered = this.datasetFilter
-      ? this.missionsByDataset[this.datasetFilter]
-      : Object.values(this.missionsByDataset).reduce(
+      ? this.missionsByDataset()[this.datasetFilter]
+      : Object.values(this.missionsByDataset()).reduce(
           (allMissions, missions) => [...allMissions, ...missions],
           [],
         );

--- a/src/app/components/shared/selectors/opera-calibration-data-selector/opera-calibration-data-selector.component.ts
+++ b/src/app/components/shared/selectors/opera-calibration-data-selector/opera-calibration-data-selector.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
-import { SubSink } from 'subsink';
 import * as filterStore from '@store/filters';
 import {
   MatRadioChange,
@@ -16,33 +15,14 @@ import { TranslateModule } from '@ngx-translate/core';
   styleUrls: ['./opera-calibration-data-selector.component.scss'],
   imports: [MatRadioGroup, MatRadioButton, TranslateModule],
 })
-export class OperaCalibrationDataSelectorComponent
-  implements OnInit, OnDestroy
-{
+export class OperaCalibrationDataSelectorComponent {
   private store$ = inject<Store<AppState>>(Store);
 
-  public useCalibrationData = false;
-
-  private subs = new SubSink();
-
-  public ngOnInit(): void {
-    this.subs.add(
-      this.store$
-        .select(filterStore.getUseCalibrationData)
-        .subscribe(
-          (useCalibrationData) =>
-            (this.useCalibrationData = useCalibrationData),
-        ),
-    );
-  }
+  public useCalibrationData = this.store$.selectSignal(
+    filterStore.getUseCalibrationData,
+  );
 
   public onToggle(event: MatRadioChange): void {
-    this.useCalibrationData = event.value;
-    this.store$.dispatch(
-      new filterStore.setUseCalibrationData(this.useCalibrationData),
-    );
-  }
-  public ngOnDestroy() {
-    this.subs.unsubscribe();
+    this.store$.dispatch(new filterStore.setUseCalibrationData(event.value));
   }
 }

--- a/src/app/components/shared/selectors/project-name-selector/project-name-selector.component.ts
+++ b/src/app/components/shared/selectors/project-name-selector/project-name-selector.component.ts
@@ -108,7 +108,7 @@ export class ProjectNameSelectorComponent implements OnInit, OnDestroy {
             return names;
           }, new Set<string>(this.projectNames));
 
-        this.projectNames = [...Array.from(projectNamesSet)];
+        this.projectNames = Array.from(projectNamesSet);
       }),
     );
   }

--- a/src/app/components/shared/selectors/search-type-selector/search-type-selector.component.html
+++ b/src/app/components/shared/selectors/search-type-selector/search-type-selector.component.html
@@ -13,11 +13,11 @@
           [matMenuTriggerFor]="searchTypeMenu"
           class="button-menu-trigger"
           color="basic"
-          matTooltip="{{ searchTranslation[searchType] | translate }}"
+          [matTooltip]="searchTranslation[searchType()] | translate"
           mat-button
         >
           <div class="button-text">
-            {{ searchTranslation[searchType] | translate }}
+            {{ searchTranslation[searchType()] | translate }}
             <span class="mat-select-arrow"></span>
           </div>
         </button>
@@ -59,7 +59,7 @@
                       </span>
                     }
                     <app-docs-modal
-                      url="{{ type.helpUrl }}"
+                      [url]="type.helpUrl"
                       class="read-more-icon"
                     ></app-docs-modal>
                   </div>
@@ -71,7 +71,7 @@
                     </span>
                   }
                   @if (type.iconType === iconTypes.IMAGE) {
-                    <img src="{{ type.icon }}" class="menu-item-icon" />
+                    <img [src]="type.icon" class="menu-item-icon" />
                   }
                 </div>
               </div>
@@ -86,7 +86,7 @@
           class="menu-item"
           mat-menu-item
           (click)="onSetSearchType(searchTypes.CUSTOM_PRODUCTS)"
-          [ngClass]="{ 'disable-search-type-on-demand': !isLoggedIn }"
+          [ngClass]="{ 'disable-search-type-on-demand': !isLoggedIn() }"
         >
           <div class="menu-item-inner">
             <div class="fx-80 menu-item-content">
@@ -94,7 +94,7 @@
                 {{ 'ON_DEMAND_PRODUCTS' | translate }}
                 <span
                   class="login-prompt"
-                  [ngClass]="{ 'login-hidden': isLoggedIn }"
+                  [ngClass]="{ 'login-hidden': isLoggedIn() }"
                 >
                   {{ 'SIGN_IN_TO_ACCESS' | translate }}
                 </span>

--- a/src/app/components/shared/selectors/search-type-selector/search-type-selector.component.ts
+++ b/src/app/components/shared/selectors/search-type-selector/search-type-selector.component.ts
@@ -1,13 +1,4 @@
-import {
-  Component,
-  OnInit,
-  OnDestroy,
-  ViewChild,
-  Input,
-  ElementRef,
-  inject,
-} from '@angular/core';
-import { SubSink } from 'subsink';
+import { Component, ViewChild, Input, ElementRef, inject } from '@angular/core';
 
 import { MatMenu, MatMenuTrigger, MatMenuItem } from '@angular/material/menu';
 
@@ -55,7 +46,7 @@ declare global {
     TranslateModule,
   ],
 })
-export class SearchTypeSelectorComponent implements OnInit, OnDestroy {
+export class SearchTypeSelectorComponent {
   translate = inject(TranslateService);
   private store$ = inject<Store<AppState>>(Store);
   private screenSize = inject(ScreenSizeService);
@@ -67,15 +58,14 @@ export class SearchTypeSelectorComponent implements OnInit, OnDestroy {
   @Input() selected: string;
   param = { value: ' world' };
 
-  public searchType: models.SearchType = models.SearchType.DATASET;
+  public searchType = this.store$.selectSignal(searchStore.getSearchType);
   public searchTypes = models.SearchType;
   public iconTypes = models.IconType;
   public searchTranslation = models.SearchTypeTranslation;
   public datasets = derivedDatasets;
   public breakpoint$ = this.screenSize.breakpoint$;
   public breakpoints = Breakpoints;
-  public isLoggedIn = false;
-  private subs = new SubSink();
+  public isLoggedIn = this.store$.selectSignal(userStore.getIsUserLoggedIn);
   public isReadMore = true;
 
   public isHyp3Plus = this.store$.selectSignal(searchStore.getHyp3PlusMode);
@@ -180,20 +170,6 @@ export class SearchTypeSelectorComponent implements OnInit, OnDestroy {
     ],
   };
 
-  ngOnInit() {
-    this.subs.add(
-      this.store$.select(searchStore.getSearchType).subscribe((searchType) => {
-        this.searchType = searchType;
-      }),
-    );
-
-    this.subs.add(
-      this.store$
-        .select(userStore.getIsUserLoggedIn)
-        .subscribe((isLoggedIn) => (this.isLoggedIn = isLoggedIn)),
-    );
-  }
-
   public onSetSearchType(searchType: models.SearchType): void {
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({
@@ -230,9 +206,5 @@ export class SearchTypeSelectorComponent implements OnInit, OnDestroy {
   public onCloseMenu(event: Event) {
     this.trigger.closeMenu();
     event.stopPropagation();
-  }
-
-  ngOnDestroy() {
-    this.subs.unsubscribe();
   }
 }

--- a/src/app/components/shared/selectors/short-name-selector/short-name-selector.component.html
+++ b/src/app/components/shared/selectors/short-name-selector/short-name-selector.component.html
@@ -8,16 +8,16 @@
     placeholder="{{ 'SHORT_NAME' | translate }}"
     multiple
   >
-    @for (type of selectableShortNames; track type) {
+    @for (type of selectableShortNames(); track type) {
       <mat-option [value]="type.apiValue" [matTooltip]="type.apiValue">
         {{ type.displayName }}
       </mat-option>
     }
   </mat-select>
 
-  @if (selectableShortNames.length >= 1) {
+  @if (selectableShortNames().length >= 1) {
     <mat-hint align="start">
-      {{ shortNamesList?.length || 0 }}/{{ selectableShortNames.length }}
+      {{ shortNamesList?.length || 0 }}/{{ selectableShortNames().length }}
       {{ 'SHORT_NAMES_SELECTED' | translate }}
     </mat-hint>
   }

--- a/src/app/components/shared/selectors/short-name-selector/short-name-selector.component.ts
+++ b/src/app/components/shared/selectors/short-name-selector/short-name-selector.component.ts
@@ -5,6 +5,7 @@ import {
   EventEmitter,
   OnDestroy,
   inject,
+  computed,
 } from '@angular/core';
 import * as models from '@models';
 import * as filtersStore from '@store/filters';
@@ -39,21 +40,15 @@ export class ShortNameSelectorComponent implements OnInit, OnDestroy {
   private store$ = inject<Store<AppState>>(Store);
 
   @Output() shortNamesChange = new EventEmitter<models.DatasetShortName>();
-  public dataset: models.Dataset;
+  public dataset = this.store$.selectSignal(filtersStore.getSelectedDataset);
   public shortNamesList: string[] = [];
-  public selectableShortNames: models.ShortName[] = [];
-
-  private dataset$ = this.store$.select(filtersStore.getSelectedDataset);
+  public selectableShortNames = computed(() => {
+    return this.dataset()?.shortNames ?? [];
+  });
 
   private subs = new SubSink();
 
   ngOnInit(): void {
-    this.subs.add(
-      this.dataset$.subscribe((dataset) => {
-        this.dataset = dataset;
-        this.selectableShortNames = dataset?.shortNames ?? [];
-      }),
-    );
     this.subs.add(
       this.store$
         .select(filtersStore.getShortNames)
@@ -74,7 +69,7 @@ export class ShortNameSelectorComponent implements OnInit, OnDestroy {
   }
 
   public emitShortNames(shortNameAPIValues: string[]): void {
-    const shortNames = this.dataset?.shortNames ?? [];
+    const shortNames = this.dataset()?.shortNames ?? [];
     const output = shortNameAPIValues.map((shortName) =>
       shortNames.find((datasetType) => datasetType.apiValue === shortName),
     );

--- a/src/app/components/sidebar/save-user-filters/save-user-filters.component.html
+++ b/src/app/components/sidebar/save-user-filters/save-user-filters.component.html
@@ -11,34 +11,32 @@
   </div>
 
   <div class="content-wrapper">
-    @if (searchType$ | async; as searchType) {
-      <div
-        [ngClass]="{
-          'saved-filters-presets__content-mobile':
-            breakpoint <= breakpoints.SMALL,
-          'saved-filters-presets__content': breakpoint > breakpoints.SMALL,
-        }"
-      >
-        @if (displayedFilter.length > 0) {
-          <div>
-            @for (filterPreset of displayedFilter; track filterPreset) {
-              <div class="saved-filters-presets-row">
-                <app-save-user-filter
-                  [filterPreset]="filterPreset"
-                  [isNew]="filterPreset.id === newSearchId"
-                  (updateName)="updatedSearchName($event)"
-                >
-                </app-save-user-filter>
-              </div>
-            }
-          </div>
-        } @else {
-          <div class="no-saved-filters-presets">
-            <h2>{{ 'YOU_HAVE_NO_SAVED_FILTERS' | translate }}</h2>
-          </div>
-        }
-      </div>
-    }
+    <div
+      [ngClass]="{
+        'saved-filters-presets__content-mobile':
+          breakpoint <= breakpoints.SMALL,
+        'saved-filters-presets__content': breakpoint > breakpoints.SMALL,
+      }"
+    >
+      @if (displayedFilter.length > 0) {
+        <div>
+          @for (filterPreset of displayedFilter; track filterPreset) {
+            <div class="saved-filters-presets-row">
+              <app-save-user-filter
+                [filterPreset]="filterPreset"
+                [isNew]="filterPreset.id === newSearchId"
+                (updateName)="updatedSearchName($event)"
+              >
+              </app-save-user-filter>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="no-saved-filters-presets">
+          <h2>{{ 'YOU_HAVE_NO_SAVED_FILTERS' | translate }}</h2>
+        </div>
+      }
+    </div>
   </div>
 
   <div

--- a/src/app/components/sidebar/save-user-filters/save-user-filters.component.ts
+++ b/src/app/components/sidebar/save-user-filters/save-user-filters.component.ts
@@ -9,7 +9,7 @@ import * as models from '@models';
 import { SubSink } from 'subsink';
 import { map } from 'rxjs/operators';
 import { ScreenSizeService } from '@services';
-import { NgClass, AsyncPipe } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { SaveUserFilterComponent } from './save-user-filter/save-user-filter.component';
 import { MatButton } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
@@ -17,14 +17,7 @@ import { TranslateModule } from '@ngx-translate/core';
   selector: 'app-save-user-filters',
   templateUrl: './save-user-filters.component.html',
   styleUrls: ['./save-user-filters.component.scss'],
-  imports: [
-    NgClass,
-
-    SaveUserFilterComponent,
-    MatButton,
-    AsyncPipe,
-    TranslateModule,
-  ],
+  imports: [NgClass, SaveUserFilterComponent, MatButton, TranslateModule],
 })
 export class SaveUserFiltersComponent implements OnInit, OnDestroy {
   private store$ = inject<Store<AppState>>(Store);
@@ -34,8 +27,7 @@ export class SaveUserFiltersComponent implements OnInit, OnDestroy {
   public breakpoint: models.Breakpoints;
   public breakpoints = models.Breakpoints;
 
-  public searchType$ = this.store$.select(searchStore.getSearchType);
-  public searchType: models.SearchType;
+  public searchType = this.store$.selectSignal(searchStore.getSearchType);
   public SearchType = models.SearchType;
 
   public saveFilterOn: boolean;
@@ -92,19 +84,13 @@ export class SaveUserFiltersComponent implements OnInit, OnDestroy {
         this.displayedFilter = output.reverse();
       }),
     );
-
-    this.subs.add(
-      this.searchType$.subscribe((searchType) => {
-        this.searchType = searchType;
-      }),
-    );
   }
 
   public filterBySearchType(filters: models.SavedFilterPreset[]) {
     let output = filters.filter(
       (preset) => preset.searchType === this.currentSearchType,
     );
-    if (this.searchType === SearchType.DATASET) {
+    if (this.searchType() === SearchType.DATASET) {
       output = output.map((preset) => ({
         ...preset,
         filters: {

--- a/src/app/components/sidebar/saved-searches/saved-searches.component.html
+++ b/src/app/components/sidebar/saved-searches/saved-searches.component.html
@@ -6,10 +6,10 @@
 >
   <div class="saved-searches__header">
     <div class="saved-searches__header-title">
-      @if (sidebarType === SidebarType.SAVED_SEARCHES) {
+      @if (sidebarType() === SidebarType.SAVED_SEARCHES) {
         <span>{{ 'SAVED_SEARCHES' | translate }}</span>
       }
-      @if (sidebarType === SidebarType.SEARCH_HISTORY) {
+      @if (sidebarType() === SidebarType.SEARCH_HISTORY) {
         <span>{{ 'SEARCH_HISTORY' | translate }}</span>
       }
     </div>
@@ -19,7 +19,7 @@
           [hideSingleSelectionIndicator]="true"
           [hideMultipleSelectionIndicator]="true"
           (change)="onSidebarTypeChange($event.value)"
-          [value]="sidebarType"
+          [value]="sidebarType()"
           name="SavedSearchType"
           [attr.aria-label]="'SAVED_SEARCH_TYPE' | translate"
           [hideSingleSelectionIndicator]="true"
@@ -59,7 +59,7 @@
 
     <div class="saved-searches__save-button">
       @if (
-        sidebarType === SidebarType.SAVED_SEARCHES &&
+        sidebarType() === SidebarType.SAVED_SEARCHES &&
         (searchType$ | async) !== SearchType.CUSTOM_PRODUCTS
       ) {
         <button (click)="saveCurrentSearch()" mat-raised-button color="accent">
@@ -89,7 +89,7 @@
                       [isExpanded]="search.id === expandedSearchId"
                       [isNew]="search.id === newSearchId"
                       [isSavedSearch]="
-                        sidebarType === SidebarType.SAVED_SEARCHES
+                        sidebarType() === SidebarType.SAVED_SEARCHES
                       "
                       [lockedFocus]="lockedFocus"
                       (unlockFocus)="onUnlockFocus()"

--- a/src/app/components/sidebar/saved-searches/saved-searches.component.ts
+++ b/src/app/components/sidebar/saved-searches/saved-searches.component.ts
@@ -68,17 +68,18 @@ export class SavedSearchesComponent implements OnInit, OnDestroy {
   public searchType$ = this.store$.select(searchStore.getSearchType);
   public SearchType = models.SearchType;
 
-  public sidebarType$ = this.store$.select(uiStore.getSidebar);
-  public sidebarType: models.SidebarType;
+  public sidebarType = this.store$.selectSignal(uiStore.getSidebar);
   public SidebarType = models.SidebarType;
 
-  public searches$ = this.sidebarType$.pipe(
-    switchMap((savedSearchType) =>
-      savedSearchType === models.SidebarType.SAVED_SEARCHES
-        ? this.store$.select(userStore.getSavedSearches)
-        : this.store$.select(userStore.getSearchHistory),
-    ),
-  );
+  public searches$ = this.store$
+    .select(uiStore.getSidebar)
+    .pipe(
+      switchMap((savedSearchType) =>
+        savedSearchType === models.SidebarType.SAVED_SEARCHES
+          ? this.store$.select(userStore.getSavedSearches)
+          : this.store$.select(userStore.getSearchHistory),
+      ),
+    );
   public lockedFocus = false;
 
   public breakpoint: models.Breakpoints;
@@ -98,12 +99,6 @@ export class SavedSearchesComponent implements OnInit, OnDestroy {
     this.subs.add(
       this.screenSize.breakpoint$.subscribe(
         (breakpoint) => (this.breakpoint = breakpoint),
-      ),
-    );
-
-    this.subs.add(
-      this.sidebarType$.subscribe(
-        (sidebarType) => (this.sidebarType = sidebarType),
       ),
     );
 

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -1,12 +1,12 @@
 <div (keydown.escape)="onCloseSidebar()">
   @if (
-    sidebar === SidebarType.SAVED_SEARCHES ||
-    sidebar === SidebarType.SEARCH_HISTORY
+    sidebar() === SidebarType.SAVED_SEARCHES ||
+    sidebar() === SidebarType.SEARCH_HISTORY
   ) {
     <app-saved-searches> </app-saved-searches>
   }
 
-  @if (sidebar === SidebarType.USER_FILTERS) {
+  @if (sidebar() === SidebarType.USER_FILTERS) {
     <app-save-user-filters> </app-save-user-filters>
   }
 </div>

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
-import { SubSink } from 'subsink';
+import { Component, inject } from '@angular/core';
 
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
@@ -15,27 +14,13 @@ import { SaveUserFiltersComponent } from './save-user-filters/save-user-filters.
   styleUrls: ['./sidebar.component.scss'],
   imports: [SavedSearchesComponent, SaveUserFiltersComponent],
 })
-export class SidebarComponent implements OnInit, OnDestroy {
+export class SidebarComponent {
   private store$ = inject<Store<AppState>>(Store);
 
-  public sidebar: models.SidebarType;
+  public sidebar = this.store$.selectSignal(uiStore.getSidebar);
   public SidebarType = models.SidebarType;
-
-  private subs = new SubSink();
-
-  ngOnInit(): void {
-    this.subs.add(
-      this.store$.select(uiStore.getSidebar).subscribe((sidebar) => {
-        this.sidebar = sidebar;
-      }),
-    );
-  }
 
   public onCloseSidebar(): void {
     this.store$.dispatch(new uiStore.CloseSidebar());
-  }
-
-  ngOnDestroy() {
-    this.subs.unsubscribe();
   }
 }

--- a/src/app/components/timeseries-chart/timeseries-chart-config/timeseries-chart-config.component.html
+++ b/src/app/components/timeseries-chart/timeseries-chart-config/timeseries-chart-config.component.html
@@ -1,10 +1,10 @@
 <div style="display: flex; flex-direction: column">
-  <mat-checkbox (change)="onToggleLines($event)" [checked]="showLines">{{
+  <mat-checkbox (change)="onToggleLines($event)" [checked]="showLines()">{{
     'SHOW_LINES' | translate
   }}</mat-checkbox>
   <mat-checkbox
     (change)="onToggleLinearFit($event)"
-    [checked]="showLinearFit"
+    [checked]="showLinearFit()"
     >{{ 'SHOW_LINEAR_FIT' | translate }}</mat-checkbox
   >
   <button mat-button (click)="resetReference()">

--- a/src/app/components/timeseries-chart/timeseries-chart-config/timeseries-chart-config.component.ts
+++ b/src/app/components/timeseries-chart/timeseries-chart-config/timeseries-chart-config.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  OnDestroy,
-  OnInit,
-  Output,
-  EventEmitter,
-  inject,
-} from '@angular/core';
+import { Component, Output, EventEmitter, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import {
@@ -14,7 +7,6 @@ import {
 } from '@angular/material/checkbox';
 import { Store } from '@ngrx/store';
 import { AppState } from '@store';
-import { SubSink } from 'subsink';
 import * as chartsStore from '@store/charts';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -24,12 +16,11 @@ import { TranslateModule } from '@ngx-translate/core';
   templateUrl: './timeseries-chart-config.component.html',
   styleUrl: './timeseries-chart-config.component.scss',
 })
-export class TimeseriesChartConfigComponent implements OnInit, OnDestroy {
+export class TimeseriesChartConfigComponent {
   private store$ = inject<Store<AppState>>(Store);
 
-  private subs = new SubSink();
-  public showLines = true;
-  public showLinearFit = false;
+  public showLines = this.store$.selectSignal(chartsStore.getShowLines);
+  public showLinearFit = this.store$.selectSignal(chartsStore.getShowLinearFit);
   @Output() public resetReferenceEvent = new EventEmitter();
 
   public onToggleLines(event: MatCheckboxChange) {
@@ -47,24 +38,7 @@ export class TimeseriesChartConfigComponent implements OnInit, OnDestroy {
     }
   }
 
-  ngOnInit(): void {
-    this.subs.add(
-      this.store$
-        .select(chartsStore.getShowLines)
-        .subscribe((showLines) => (this.showLines = showLines)),
-    );
-    this.subs.add(
-      this.store$
-        .select(chartsStore.getShowLinearFit)
-        .subscribe((showLinearFit) => (this.showLinearFit = showLinearFit)),
-    );
-  }
-
   public resetReference() {
     this.resetReferenceEvent.emit();
-  }
-
-  ngOnDestroy(): void {
-    this.subs.unsubscribe();
   }
 }

--- a/src/app/store/filters/filters.reducer.ts
+++ b/src/app/store/filters/filters.reducer.ts
@@ -813,13 +813,13 @@ export function filtersReducer(
     case FiltersActionType.SET_FULL_BURSTS: {
       return {
         ...state,
-        fullBurstIDs: [...new Set([...action.payload])],
+        fullBurstIDs: [...new Set(action.payload)],
       };
     }
     case FiltersActionType.SET_OPERA_BURST_IDS: {
       return {
         ...state,
-        operaBurstIDs: [...new Set([...action.payload])],
+        operaBurstIDs: [...new Set(action.payload)],
       };
     }
     case FiltersActionType.ADD_FULL_BURSTS: {

--- a/src/app/store/queue/queue.effect.ts
+++ b/src/app/store/queue/queue.effect.ts
@@ -92,7 +92,7 @@ export class QueueEffects {
           ([format, searchParams]): MetadataDownload => ({
             params: {
               ...searchParams,
-              ...{ output: format.toLowerCase() },
+              output: format.toLowerCase(),
             },
             format: format,
           }),
@@ -117,7 +117,7 @@ export class QueueEffects {
         ),
         map(
           ([format, params]): MetadataDownload => ({
-            params: { ...params, ...{ output: format } },
+            params: { ...params, output: format },
             format,
           }),
         ),


### PR DESCRIPTION
## Summary
Converts the rest of the components not migrated with the basic signal pass over. Notable exceptions include selectors that are using `ngModel` for form values, those are a bit weirder to change over and will be done later.

Also enables an eslint rule for checking signals are called for accessing them in typescript. It seems to _kind of_ work but misses some stuff still.
