### PR TITLE
Turn off related data for NISAR products

### DIFF
--- a/src/app/components/results-menu/scene-files/scene-files.component.ts
+++ b/src/app/components/results-menu/scene-files/scene-files.component.ts
@@ -233,10 +233,8 @@ export class SceneFilesComponent implements OnInit, OnDestroy {
     distinctUntilChanged((prev, curr) => prev?.id === curr?.id),
     withLatestFrom(this.store$.select(filterStore.getUseCalibrationData)),
     map(([scene, useCalibrationData]) => {
-      return (
-        this.operaSubqueryCriteria(scene, useCalibrationData) ||
-        this.nisarSubqueryCriteria(scene)
-      );
+      return this.operaSubqueryCriteria(scene, useCalibrationData);
+      // || this.nisarSubqueryCriteria(scene)
     }),
   );
 
@@ -251,6 +249,11 @@ export class SceneFilesComponent implements OnInit, OnDestroy {
       scene?.id.startsWith('OPERA')
     );
   }
+
+  /*
+   * Removed because this is yeilding the wrong orbit files and there isn't a
+   * well defined way of which orbits to show for each product
+   *
   private nisarSubqueryCriteria(scene: models.CMRProduct) {
     const isNisar = !!scene && scene.id?.startsWith('NISAR');
     const processingLevel = scene?.metadata?.productType ?? '';
@@ -270,6 +273,8 @@ export class SceneFilesComponent implements OnInit, OnDestroy {
       ].includes(processingLevel)
     );
   }
+  */
+
   public dynamicallySearchedProduct$ = combineLatest([
     this.store$.select(scenesStore.getSelectedScene),
     this.nisarOrbitEphemera$,


### PR DESCRIPTION
## Summary
Turn off related data because they are showing incorrect orbit files for NISAR products. There is also not a clear algorithm on which orbits to associated to which products. Maybe in the future we can turn this back on and update which orbits get shown.

## Screenshots / UI Changes
Before:
<img width="636" height="405" alt="image" src="https://github.com/user-attachments/assets/e96f52b4-88bc-47e2-a512-abe85e07c690" />

After:
<img width="636" height="405" alt="image" src="https://github.com/user-attachments/assets/0772c42a-1d5e-40a1-ba94-b4468fa68211" />

## Notes
Left all the code just turned off loading it for NISAR data.